### PR TITLE
Fixed a stubbed out init() method in seq_data class.

### DIFF
--- a/types/seq_data.h
+++ b/types/seq_data.h
@@ -27,7 +27,7 @@ using boost::numeric::ublas::vector;
 class USML_DECLSPEC seq_data : public seq_vector {
 
     //**************************************************
-    // type definisions
+    // type definitions
 
     typedef seq_data self_type;
 public:
@@ -109,7 +109,7 @@ public:
      * Search for a value in this sequence. If the value is outside of the
      * legal range, the index for the nearest endpoint will be returned,
      * unless the nearest endpoint is that last index, in which the second
-     * to last index will be returned. This is to garuntee that there is
+     * to last index will be returned. This is to guarantee that there is
      * always an index to the right of the returned index.
      *
      * @param   value       Value of the element to find.

--- a/types/seq_vector.h
+++ b/types/seq_vector.h
@@ -125,10 +125,10 @@ public:
 
 protected:
     /** Number of elements in the sequence. */
-    const size_type _size;
+    size_type _size;
 
     /** Largest valid index number (one less than _size). */
-    const size_type _max_index ;
+    size_type _max_index ;
 
 public:
     /**

--- a/types/test/datagrid_test.cc
+++ b/types/test/datagrid_test.cc
@@ -74,8 +74,9 @@ BOOST_AUTO_TEST_CASE( compute_index_test ) {
             for ( iterator iz = z.begin(); iz < z.end(); ++iz ) {
                 index[2] = c++;
                 k = data_grid_compute_offset<2>( axis, index );
-                printf( "x=%u y=%u z=%u offset=%02u data=%03.0f\n",
-                        a-1, b-1, c-1, k, data[k] );
+                printf( "x=%lu y=%lu z=%lu offset=%02lu data=%03.0f\n",
+                        (unsigned long)(a-1), (unsigned long)(b-1),
+                        (unsigned long)(c-1), (unsigned long)k, data[k] );
                 BOOST_CHECK_CLOSE( data[k], *ix + *iy + *iz, 1e-6 );
             }
         }

--- a/waveq3d/wave_front.cc
+++ b/waveq3d/wave_front.cc
@@ -186,8 +186,8 @@ void wave_front::find_edges() {
     }
 
     // search for a local maxima or minima in the rho direction
-    const size_t max_az = num_az() - 1 ;
-	for ( size_t az=0 ; az < num_az() ; az++ ) {
+
+    for ( size_t az=0 ; az < num_az() ; az++ ) {
 		for ( size_t de=1 ; de < max_de ; de++ ) {
 			bool change_family = surface(de,az) != surface(de+1,az) ||
 								 bottom(de,az) != bottom(de+1,az) ||


### PR DESCRIPTION
I ran into this while working on ARL/UT accuracy study.
- Move initialization logic from constructors into init().
- Have constructors call logic in init().
- This allows sub-classes of seq_data to re-use this logic.
- This update does not change API.