### PR TITLE
Added boundary_lock and profile_lock classes to the ocean package. Closes issue #102.

### DIFF
--- a/config/USMLUse.cmake
+++ b/config/USMLUse.cmake
@@ -82,10 +82,21 @@ set(Boost_ADDITIONAL_VERSIONS
 	"1.52" "1.52.0" "1.53" "1.53.0" "1.55" "1.55.0"
 	"1.56" "1.56.0" "1.57" "1.57.0"
 )
-find_package( Boost 1.41 REQUIRED COMPONENTS
-    unit_test_framework	# for usml_test.exe
-    thread
-)
+if( MSVC )
+    find_package( Boost 1.41 REQUIRED COMPONENTS
+        unit_test_framework	# for usml_test.exe
+        thread
+        date_time
+        system
+        chrono
+    )
+else ( MSVC )
+    find_package( Boost 1.41 REQUIRED COMPONENTS
+        unit_test_framework	# for usml_test.exe
+        thread
+    )
+endif ( MSVC )
+
 include_directories( ${Boost_INCLUDE_DIR} )
 
 # fix bug in boost/numeric/ublas/vector_expression.hpp lines 1409 through 1417

--- a/config/USMLUse.cmake
+++ b/config/USMLUse.cmake
@@ -84,6 +84,7 @@ set(Boost_ADDITIONAL_VERSIONS
 )
 find_package( Boost 1.41 REQUIRED COMPONENTS
     unit_test_framework	# for usml_test.exe
+    thread
 )
 include_directories( ${Boost_INCLUDE_DIR} )
 

--- a/ocean/boundary_lock.h
+++ b/ocean/boundary_lock.h
@@ -1,0 +1,120 @@
+/**
+ * @file boundary_lock.h
+ * A wrapper for a boundary model that provides each instantiation with its own set
+ * of mutex's for the height() and reflect_loss() methods.
+ */
+#pragma once
+
+#include <boost/thread.hpp>
+#include <usml/ocean/boundary_model.h>
+
+namespace usml {
+namespace ocean {
+
+using boost::numeric::ublas::vector;
+
+/// @ingroup boundaries
+/// @{
+
+/**
+ * A wrapper for a boundary model that provides each instantiation with its own set
+ * of mutex's for the height() and reflect_loss() methods.
+ */
+class USML_DECLSPEC boundary_lock : public boundary_model {
+
+   private:
+
+        /** Mutex's to prevent simultaneous access/update by multiple threads. */
+		boost::mutex* _heightMutex ;
+		boost::mutex* _reflect_lossMutex ;
+		/** The "has a" object to prevent simultaneous access */
+        boundary_model* _other;
+
+    public:
+
+        /**
+         * Constructor
+         * Takes control of a profile_model and creates a mutex's for each public
+         * method and for each instantiation of the class and when done destroys both.
+         */
+        boundary_lock(boundary_model* other) : _other(other)
+        {
+            _heightMutex = new boost::mutex();
+            _reflect_lossMutex = new boost::mutex();
+        }
+
+        /**
+         * Compute the height of the boundary and it's surface normal at
+         * a series of locations with a mutex lock.
+         *
+         * @param location      Location at which to compute boundary.
+         * @param rho           Surface height in spherical earth coords (output).
+         * @param normal        Unit normal relative to location (output).
+         * @param quick_interp  Determines if you want a fast nearest or pchip interp
+         */
+        virtual void height( const wposition& location, matrix<double>* rho,
+        		wvector* normal=NULL, bool quick_interp=false )
+        {
+            // Locks mutex then unlocks on method exit
+            // Avoids try/catch on _other->height call
+            boost::lock_guard<boost::mutex> heightLock(*_heightMutex);
+
+            _other->height(location, rho, normal, quick_interp);
+        }
+
+        /**
+         * Compute the height of the boundary and it's surface normal at
+         * a single location with a mutex lock.  Often used during reflection processing.
+         *
+         * @param location      Location at which to compute boundary.
+         * @param rho           Surface height in spherical earth coords (output).
+         * @param normal        Unit normal relative to location (output).
+         * @param quick_interp  Determines if you want a fast nearest or pchip interp
+         */
+        virtual void height( const wposition1& location, double* rho,
+        		wvector1* normal=NULL, bool quick_interp=false )
+        {
+            // Locks mutex then unlocks on method exit
+            boost::lock_guard<boost::mutex> heightLock(*_heightMutex);
+
+            _other->height(location, rho, normal, quick_interp);
+        }
+
+        /**
+         * Computes the broadband reflection loss and phase change with a mutex lock.
+         *
+         * @param location      Location at which to compute attenuation.
+         * @param frequencies   Frequencies over which to compute loss. (Hz)
+         * @param angle         Grazing angle relative to the interface (radians).
+         * @param amplitude     Change in ray strength in dB (output).
+         * @param phase         Change in ray phase in dB (output).
+         */
+        virtual void reflect_loss(
+            const wposition1& location,
+            const seq_vector& frequencies, double angle,
+            boost::numeric::ublas::vector<double>* amplitude, boost::numeric::ublas::vector<double>* phase=NULL )
+        {
+            // Locks mutex then unlocks on method exit
+            boost::lock_guard<boost::mutex> reflect_lossLock(*_reflect_lossMutex);
+
+            _other->reflect_loss( location, frequencies, angle, amplitude, phase ) ;
+        }
+
+        /**
+         * Destructor
+         */
+        virtual ~boundary_lock()
+        {
+            if (_heightMutex || _reflect_lossMutex)
+            {
+                delete _heightMutex;
+                delete _reflect_lossMutex;
+                _heightMutex = _reflect_lossMutex = NULL;
+            }
+            delete _other ;
+        }
+};
+
+/// @}
+}  // end of namespace ocean
+}  // end of namespace usml

--- a/ocean/ocean.h
+++ b/ocean/ocean.h
@@ -59,6 +59,7 @@
 #include <usml/ocean/profile_catenary.h>
 #include <usml/ocean/profile_grid.h>
 #include <usml/ocean/profile_grid_fast.h>
+#include <usml/ocean/profile_lock.h>
 #include <usml/ocean/ascii_profile.h>
 #include <usml/ocean/data_grid_mackenzie.h>
 
@@ -75,6 +76,7 @@
 #include <usml/ocean/boundary_slope.h>
 #include <usml/ocean/boundary_grid.h>
 #include <usml/ocean/boundary_grid_fast.h>
+#include <usml/ocean/boundary_lock.h>
 #include <usml/ocean/ascii_arc_bathy.h>
 #include <usml/ocean/wave_height_pierson.h>
 

--- a/ocean/profile_lock.h
+++ b/ocean/profile_lock.h
@@ -1,0 +1,103 @@
+/**
+ * @file profile_lock
+ * A wrapper for a USML profile model that provides each instantiation with its own set
+ * of mutex's for the sound_speed() and attenuation() methods.
+ */
+#pragma once
+
+#include <boost/thread.hpp>
+#include <usml/ocean/profile_model.h>
+
+namespace usml {
+namespace ocean {
+
+using boost::numeric::ublas::vector;
+
+/// @ingroup profiles
+/// @{
+
+/**
+ * A wrapper for a USML profile model that provides each instantiation with its own set
+ * of mutex's for the sound_speed() and attenuation() methods.
+ */
+class USML_DECLSPEC profile_lock : public profile_model {
+
+   private:
+
+        /** Mutex to prevent simultaneous access/update by multiple threads. */
+		boost::mutex* _sound_speedMutex ;
+		boost::mutex* _attenuationMutex ;
+	    /** The "has a" object to prevent simultaneous access */
+        profile_model* _other;
+
+    public:
+
+        /**
+         * Constructor
+         * Takes control of a profile_model and creates mutex's fpr each public
+         * method and for each instantiation of the class and when done destroys both.
+         */
+        profile_lock(profile_model* other) : _other(other)
+        {
+            _sound_speedMutex = new boost::mutex();
+            _attenuationMutex = new boost::mutex();
+        }
+
+        /**
+         * Compute the speed of sound and it's first derivatives at
+         * a series of locations with a mutex lock.
+         *
+         * @param location      Location at which to compute attenuation.
+         * @param speed         Speed of sound (m/s) at each location (output).
+         * @param gradient      Sound speed gradient at each location (output).
+         */
+        virtual void sound_speed( const wposition& location,
+            matrix<double>* speed, wvector* gradient=NULL )
+        {
+            // Locks mutex then unlocks on method exit
+            // Avoids try/catch on _other->sound_speed call
+            boost::lock_guard<boost::mutex> sound_speedLock(*_sound_speedMutex);
+
+            _other->sound_speed(location, speed, gradient);
+
+        }
+
+        /**
+        * Computes the broadband absorption loss of sea water with a mutex lock.
+        *
+        * @param location      Location at which to compute attenuation.
+        * @param frequencies   Frequencies over which to compute loss. (Hz)
+        * @param distance      Distance traveled through the water (meters).
+        * @param attenuation   Absorption loss of sea water in dB (output).
+        */
+        virtual void attenuation(
+           const usml::types::wposition& location,
+           const seq_vector& frequencies,
+           const boost::numeric::ublas::matrix<double>& distance,
+           boost::numeric::ublas::matrix< boost::numeric::ublas::vector<double> >* attenuation)
+       {
+            // Locks mutex then unlocks on method exit
+            // Avoids try/catch on _other->attenuation call
+            boost::lock_guard<boost::mutex> attenuationLock(*_attenuationMutex);
+
+            _other->attenuation(location, frequencies, distance, attenuation ) ;
+       }
+
+        /**
+         * Destructor
+         */
+        virtual ~profile_lock()
+        {
+            if (_sound_speedMutex || _attenuationMutex)
+            {
+               delete _sound_speedMutex;
+               delete _attenuationMutex;
+               _sound_speedMutex = _attenuationMutex = NULL;
+            }
+            delete _other ;
+        }
+};
+
+/// @}
+}  // end of namespace ocean
+}  // end of namespace usml

--- a/ocean/profile_lock.h
+++ b/ocean/profile_lock.h
@@ -1,5 +1,5 @@
 /**
- * @file profile_lock
+ * @file profile_lock.h
  * A wrapper for a USML profile model that provides each instantiation with its own set
  * of mutex's for the sound_speed() and attenuation() methods.
  */

--- a/ocean/test/boundary_lock_test.cc
+++ b/ocean/test/boundary_lock_test.cc
@@ -1,0 +1,196 @@
+/**
+ * @example ocean/test/boundary_lock_test.cc
+ */
+#include <boost/thread.hpp>
+#include <boost/test/unit_test.hpp>
+
+#include <usml/ublas/randgen.h>
+#include <usml/netcdf/netcdf_files.h>
+#include <usml/ocean/ocean.h>
+
+
+BOOST_AUTO_TEST_SUITE(boundary_lock_test)
+
+using namespace boost::unit_test;
+using namespace usml::netcdf;
+using namespace usml::ocean;
+
+/**
+ * @ingroup ocean_test
+ * @{
+ */
+
+class USML_DECLSPEC tester_base
+{
+    public:
+
+        tester_base() :
+            _lockableBoundary(NULL)
+        {}
+
+        virtual ~tester_base()
+        {}
+
+        void random_wait()
+        {
+            double seed = randgen::uniform();
+            if (seed == 0.0) seed = 0.0001;
+            int msec = seed * 1000;
+            if (msec > 1000 ) msec = 1000;
+            boost::this_thread::sleep(boost::posix_time::milliseconds(msec));
+        }
+
+        // This is the method which gets called from inside the thread.
+        void operator () ()
+        {
+           for (int i = 0; i < 5; ++i)
+           {
+               random_wait();
+               test();
+               std::cout << "Thread " << boost::this_thread::get_id() << ": " << i << std::endl;
+           }
+        }
+
+        virtual void test() = 0;
+
+    protected:
+
+        usml::ocean::boundary_lock* _lockableBoundary;
+};
+
+class USML_DECLSPEC etopo_boundary_tester : public tester_base
+{
+    public:
+
+    void setup()
+    {
+        boundary_grid<double, 2>* model =
+            new boundary_grid<double, 2>(new netcdf_bathy(
+            USML_DATA_DIR "/bathymetry/ETOPO1_Ice_g_gmt4.grd",
+            36.0, 36.2, 15.85, 16.0, wposition::earth_radius));
+        _lockableBoundary = new boundary_lock(model);
+    }
+
+    void test()
+    {
+        // simple values for points and depth
+
+        wposition1 points;
+        points.latitude(36.000447);
+        points.longitude(15.890411);
+        double depth;
+        wvector1 normal;
+
+        // compute bathymetry
+
+        _lockableBoundary->height(points, &depth, &normal);
+
+        // check the answer
+
+        #ifdef __FAST_MATH__
+            const double depth_accuracy = 0.005 ;
+            const double normal_accuracy = 2e-4 ;
+        #else
+            const double depth_accuracy = 5e-4 ;
+            const double normal_accuracy = 2e-4 ;
+        #endif
+
+        BOOST_CHECK_CLOSE(wposition::earth_radius - depth, 3671.1557116601616, depth_accuracy );
+        BOOST_CHECK( abs(normal.theta()) < normal_accuracy );
+        BOOST_CHECK( abs(normal.phi() - 0.012764948465248139) < normal_accuracy );
+
+    }
+
+}; // end etopo_boundary_tester class
+
+BOOST_AUTO_TEST_CASE( etopo_boundary_lock_test ) {
+
+    cout << "=== boundary_lock_test: etopo_boundary_lock_test ===" << endl;
+    try {
+
+        etopo_boundary_tester etopo_boundary;
+        etopo_boundary.setup();
+
+        boost::thread t1(etopo_boundary);
+        boost::thread t2(etopo_boundary);
+
+        t1.join();
+        t2.join();
+
+    } catch (std::exception* except) {
+        BOOST_ERROR(except->what());
+    }
+}
+
+class USML_DECLSPEC reflect_loss_tester : public tester_base
+{
+    public:
+
+    void setup()
+    {
+        reflect_loss_netcdf* reflectLoss = new reflect_loss_netcdf( USML_DATA_DIR "/bottom_province/sediment_test.nc" ) ;
+
+        boundary_flat* model = new boundary_flat(1000.0, reflectLoss);
+
+        _lockableBoundary = new boundary_lock(model);
+    }
+
+    void test()
+    {
+        seq_linear frequency(1000.0, 1000.0, 0.01) ;
+        double angle = M_PI_2 ;
+        vector<double> amplitude( frequency.size() ) ;
+
+        double limestone = 3.672875 ;
+        double sand = 10.166660 ;
+        double tolerance = 4e-4 ;
+
+        /** bottom type numbers in the center of the data field top left, right, bottom left, right */
+        _lockableBoundary->reflect_loss(wposition1(29.5, -83.4), frequency, angle, &amplitude) ;
+        BOOST_CHECK_CLOSE(amplitude(0), limestone, tolerance) ;
+        _lockableBoundary->reflect_loss(wposition1(30.5, -83.4), frequency, angle, &amplitude) ;
+        BOOST_CHECK_CLOSE(amplitude(0), sand, tolerance) ;
+        _lockableBoundary->reflect_loss(wposition1(29.5, -84.2), frequency, angle, &amplitude) ;
+        BOOST_CHECK_CLOSE(amplitude(0), sand, tolerance) ;
+        _lockableBoundary->reflect_loss(wposition1(30.5, -84.2), frequency, angle, &amplitude) ;
+        BOOST_CHECK_CLOSE(amplitude(0), limestone, tolerance) ;
+        /** bottom type numbers at the corners of the data field top left, bottom left, top right, bottom right */
+        _lockableBoundary->reflect_loss(wposition1(26, -80), frequency, angle, &amplitude) ;
+        BOOST_CHECK_CLOSE(amplitude(0), sand, tolerance) ;
+        _lockableBoundary->reflect_loss(wposition1(26, -89), frequency, angle, &amplitude) ;
+        BOOST_CHECK_CLOSE(amplitude(0), limestone, tolerance) ;
+        _lockableBoundary->reflect_loss(wposition1(35, -80), frequency, angle, &amplitude) ;
+        BOOST_CHECK_CLOSE(amplitude(0), sand, tolerance) ;
+        _lockableBoundary->reflect_loss(wposition1(35, -89), frequency, angle, &amplitude) ;
+        BOOST_CHECK_CLOSE(amplitude(0), limestone, tolerance) ;
+    }
+
+}; // end reflect_loss_tester class
+
+/**
+ * Using the boundary_lock class and multiple threads test the basic features
+ * of the reflection loss model using the netCDF bottom type file.
+ * Generate errors if values differ by more that 1E-5 percent.
+ */
+BOOST_AUTO_TEST_CASE( reflect_loss_boundary_lock_test ) {
+
+    cout << "=== boundary_lock_test: reflect_loss_boundary_lock_test ===" << endl;
+    try {
+
+        reflect_loss_tester reflect_loss_boundary;
+        reflect_loss_boundary.setup();
+
+        boost::thread t1(reflect_loss_boundary);
+        boost::thread t2(reflect_loss_boundary);
+
+        t1.join();
+        t2.join();
+
+    } catch (std::exception* except) {
+        BOOST_ERROR(except->what());
+    }
+}
+
+/// @}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/ocean/test/profile_lock_test.cc
+++ b/ocean/test/profile_lock_test.cc
@@ -20,7 +20,7 @@ using namespace usml::ocean;
  * @{
  */
 
-class USML_DECLSPEC tester_base
+class tester_base
 {
     public:
 

--- a/ocean/test/profile_lock_test.cc
+++ b/ocean/test/profile_lock_test.cc
@@ -1,0 +1,238 @@
+/**
+ * @example ocean/test/profile_lock_test.cc
+ */
+#include <boost/thread.hpp>
+#include <boost/test/unit_test.hpp>
+
+#include <usml/ublas/randgen.h>
+#include <usml/netcdf/netcdf_files.h>
+#include <usml/ocean/ocean.h>
+
+
+BOOST_AUTO_TEST_SUITE(profile_lock_test)
+
+using namespace boost::unit_test;
+using namespace usml::netcdf;
+using namespace usml::ocean;
+
+/**
+ * @ingroup ocean_test
+ * @{
+ */
+
+class USML_DECLSPEC tester_base
+{
+    public:
+
+        tester_base() :
+            _lockableProfile(NULL),
+            _temp(NULL)
+        {}
+
+        virtual ~tester_base()
+        {}
+
+        void random_wait()
+        {
+            double seed = randgen::uniform();
+            if (seed == 0.0) seed = 0.0001;
+            int msec = seed * 1000;
+            if (msec > 1000 ) msec = 1000;
+            boost::this_thread::sleep(boost::posix_time::milliseconds(msec));
+        }
+
+        // This is the method which gets called from inside the thread.
+        void operator () ()
+        {
+           for (int i = 0; i < 5; ++i)
+           {
+               random_wait();
+               test();
+               std::cout << "Thread " << boost::this_thread::get_id() << ": " << i << std::endl;
+           }
+        }
+
+        virtual void test() = 0;
+
+    protected:
+
+        usml::ocean::profile_lock* _lockableProfile;
+        usml::netcdf::netcdf_woa* _temp;
+
+};
+
+class USML_DECLSPEC linear_tester : public tester_base
+{
+    public:
+
+    void setup()
+    {
+        // liner profile
+        attenuation_model* attn = new attenuation_constant(5.0);
+        profile_linear* model = new profile_linear();
+        model->attenuation(attn);
+        _lockableProfile = new profile_lock(model);
+    }
+
+    void test()
+    {
+        // simple values for points and speed
+        wposition points(1, 1);
+        matrix<double> speed(1, 1);
+        wvector gradient(1, 1);
+
+        _lockableProfile->sound_speed(points, &speed, &gradient);
+
+        // check the answer
+        BOOST_CHECK_CLOSE(speed(0, 0), 1500.0, 1e-6);
+
+        // setup for attenuation check
+        seq_linear freq(10.0,1.0,1);
+        scalar_matrix<double> distance(1,1,1);
+        matrix< vector<double> > result(1,1);
+        result(0,0) = scalar_vector<double> (1,1);
+
+        _lockableProfile->attenuation(points, freq, distance, &result);
+
+        // check the answer
+        BOOST_CHECK_CLOSE((result(0, 0))[0], 50.0, 1e-6);
+    }
+
+}; // end linear_tester class
+
+class USML_DECLSPEC mackenzie_tester : public tester_base
+{
+    public:
+
+    void setup()
+    {
+        int month = 6;
+        wposition::compute_earth_radius((18.5 + 22.5) / 2.0);
+
+        // load temperature & salinity data from World Ocean Atlas
+        _temp = new netcdf_woa(
+        USML_DATA_DIR "/woa09/temperature_seasonal_1deg.nc",
+        USML_DATA_DIR "/woa09/temperature_monthly_1deg.nc",
+            month, 18.5, 22.5, 200.5, 205.5 ) ;
+        netcdf_woa* temperature = new netcdf_woa(
+        USML_DATA_DIR "/woa09/temperature_seasonal_1deg.nc",
+        USML_DATA_DIR "/woa09/temperature_monthly_1deg.nc",
+            month, 18.5, 22.5, 200.5, 205.5 ) ;
+        netcdf_woa* salinity = new netcdf_woa(
+        USML_DATA_DIR "/woa09/salinity_seasonal_1deg.nc",
+        USML_DATA_DIR "/woa09/salinity_monthly_1deg.nc",
+            month, 18.5, 22.5, 200.5, 205.5 ) ;
+
+        // setup attenuation
+        attenuation_model* attn = new attenuation_constant(5.0);
+
+        // compute sound speed
+        profile_grid<double,3>* profile = new profile_grid<double,3>(
+            data_grid_mackenzie::construct(temperature, salinity), attn) ;
+
+        // Instance of lockable
+        _lockableProfile = new profile_lock(profile);
+    }
+
+    void test()
+    {
+        size_t index[3];
+        index[1] = 0;
+        index[2] = 0;
+
+        matrix<double> speed(1, 1);
+        wposition location(1, 1);
+        location.latitude(0, 0, 18.5);
+        location.longitude(0, 0, 200.5);
+        wvector gradient(1, 1);
+
+        for (size_t d = 0; d < _temp->axis(0)->size(); ++d)
+        {
+            index[0] = d;
+            location.rho(0, 0, (*_temp->axis(0))(d));
+
+            _lockableProfile->sound_speed(location, &speed, &gradient);
+
+            // compare to UK National Physical Laboratory software
+
+            switch (d) {
+                case 0:     // depth=0 temp=25.8543 sal=34.6954
+                    BOOST_CHECK_CLOSE( speed(0, 0), 1535.9781, 1e-3 );
+                    break;
+                case 18:    // depth=1000 temp=4.3149 sal=34.5221
+                    BOOST_CHECK_CLOSE( speed(0, 0), 1483.6464, 1e-3 );
+                    break;
+                case 32:    // depth=5500 temp=1.50817 sal=34.7001
+                    BOOST_CHECK_CLOSE( speed(0, 0), 1549.90469, 1e-3 );
+                    break;
+                default:
+                    break;
+            }
+        }
+
+        // setup for attenuation check
+       seq_linear freq(10.0,1.0,1);
+       scalar_matrix<double> distance(1,1,1);
+       matrix< vector<double> > result(1,1);
+       result(0,0) = scalar_vector<double> (1,1);
+
+       _lockableProfile->attenuation(location, freq, distance, &result);
+
+       // check the answer
+       BOOST_CHECK_CLOSE((result(0, 0))[0], 50.0, 1e-6);
+    }
+
+}; // end mackinzie_tester class
+
+
+/**
+ * Test the basic features of the profile_lock class using a constant profile model
+ * and attenuation with a random wait between start of the test.
+ * Generate errors if values differ by more that 1E-6 percent, or SIG Fault on thread error.
+ */
+BOOST_AUTO_TEST_CASE( linear_profile_lock_test ) {
+
+    cout << "=== profile_lock_test: linear_profile_lock_test ===" << endl;
+    try {
+
+        linear_tester linear;
+        linear.setup();
+        boost::thread t1(linear);
+        boost::thread t2(linear);
+
+        t1.join();
+        t2.join();
+
+    } catch (std::exception* except) {
+        BOOST_ERROR(except->what());
+    }
+}
+
+/**
+ * This test reproduces the mackenzie_profile_test found in the profile_test
+ * only accessing the profile_model with a data_grid via profile_lock class.
+ * A random wait is used between the start of each thread that performs the test.
+ * Generate errors if values differ by more that 1E-3 percent or SIG Fault on thread error.
+ */
+BOOST_AUTO_TEST_CASE( mackenzie_profile_lock_test ) {
+
+    cout << "=== profile_lock_test: mackenzie_profile_lock_test ===" << endl;
+    try {
+
+        mackenzie_tester mackenzie;
+        mackenzie.setup();
+
+        boost::thread t1(mackenzie);
+        boost::thread t2(mackenzie);
+
+        t1.join();
+        t2.join();
+
+    } catch (std::exception* except) {
+        BOOST_ERROR(except->what());
+    }
+}
+
+/// @}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/ocean/test/profile_test.cc
+++ b/ocean/test/profile_test.cc
@@ -168,8 +168,7 @@ BOOST_AUTO_TEST_CASE( compute_mackenzie_test ) {
 
         // compute sound speed
 
-        profile_grid<double,3> profile =
-            data_grid_mackenzie::construct(temperature, salinity) ;
+        profile_grid<double,3> profile(data_grid_mackenzie::construct(temperature, salinity)) ;
 
         // print results for first lat/long entry
 

--- a/types/data_grid_bathy.h
+++ b/types/data_grid_bathy.h
@@ -40,10 +40,7 @@ class USML_DECLSPEC data_grid_bathy: public data_grid<double, 2> {
          * used at a later time during pchip calculations.
          *
          * @param grid      The data_grid that is to be wrapped.
-         * @param copy_data If true, copies the data grids data
-         *                  fields as well as the axises.
          */
-
         data_grid_bathy(const data_grid<double, 2>* grid) :
                 data_grid<double, 2>(*grid, true), _bicubic_coeff(16, 1),
                 _field(16, 1), _xyloc(1, 16), _result_pchip(1, 1), _value(4, 4),

--- a/types/data_grid_svp.h
+++ b/types/data_grid_svp.h
@@ -39,10 +39,7 @@ class USML_DECLSPEC data_grid_svp: public data_grid<double, 3> {
          * data_grid.
          *
          * @param grid      The data_grid that is to be wrapped.
-         * @param copy_data If true, copies the data grids data
-         *                  fields as well as the axises.
          */
-
         data_grid_svp( const data_grid<double, 3>* grid )
             :   data_grid<double, 3>(*grid, true),
                 _kzmax(_axis[0]->size() - 1u),

--- a/types/seq_data.h
+++ b/types/seq_data.h
@@ -55,7 +55,8 @@ protected:
      * Initialize sequence from a uBLAS vector.
      * Ensures that the sequence is a monotonic sequence.
      *
-     * @param  data		          Set of data elements to use.
+     * @param  data  Set of data elements to use.
+     * @param  size  Number of data elements.
      * @throws invalid_argument   If series not monotonic
      */
     void init( const double* data, size_t size ) {

--- a/usml_release_notes.html
+++ b/usml_release_notes.html
@@ -6,7 +6,7 @@
   <body>
     <h1>Under Sea Modeling Library (USML) Release Notes</h1>
     
-    <h2>Release 1.0.0rc2 - Dec 2014</h2>
+    <h2>Release 1.0.0rc2 - Jan 2015</h2>
     <ul>
 	<li>Bugs</li>
 	<ul>
@@ -15,6 +15,7 @@
 	</ul>
 	<li>Enhancements</li>
 	<ul>
+	    <li>Added profile_lock and boundary_lock classes to allow multiple threads to access boundary_model(s) and profile_model(s) via boost mutexs.
 	    <li>Add checkEigenray() method to eigenrayListener interface to support support returning of eigenray as quickly as possible.
 	    <li>Added macros to usml_config.h to prevent Eclipse from finding semantic errors on macro that are not specfied until the compile line "-D".
             <li>Guard against starting wavefront below bottom or above surface. Automatically adjusts source location if it is within 0.1 meters of being above the ocean surface or below the ocean bottom.


### PR DESCRIPTION
Also added boundary_lock_test and profile_lock_test to the ocean/test
package.
Required adding boost thread library to USMLUse.cmake for mutex's and
thread's for testing.