### PR TITLE
Updated Beam pattern classes and sensor module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@
 /scripts
 /msg
 /usml.spec
+*.eps

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,7 +30,7 @@ file(STRINGS config/VERSION.txt PACKAGE_VERSION)
 message(STATUS "USML version ${PACKAGE_VERSION}" )
 set( CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/config" )
 
-set( PACKAGE_MODULES ublas types netcdf ocean waveq3d)
+set( PACKAGE_MODULES ublas types netcdf ocean sensors waveq3d)
 if( MSVC )	# work around for missing netcdf_c++ on windows
     set( PACKAGE_MODULES ${PACKAGE_MODULES} netcdf/msvc )
 endif( MSVC )	

--- a/ocean/reflect_loss_netcdf.cc
+++ b/ocean/reflect_loss_netcdf.cc
@@ -51,7 +51,7 @@ reflect_loss_netcdf::reflect_loss_netcdf(const char* filename) {
     double* shearatten = new double[n_types] ;
         bot_shear_atten->get(&shearatten[0], n_types) ;
 
-    /** Creates a sequence vector of axises that are passed to the data grid constructor */
+    /** Creates a sequence vector of axes that are passed to the data grid constructor */
     seq_vector* axis[2];
     double latinc = ( latitude[latdim-1] - latitude[0] ) / latdim ;
     axis[0] = new seq_linear(latitude[0], latinc, int(latdim));

--- a/sensors/beam_pattern_cosine.cc
+++ b/sensors/beam_pattern_cosine.cc
@@ -1,0 +1,37 @@
+/**
+ * @file beam_pattern_cosine.cc
+ */
+
+#include <usml/sensors/beam_pattern_cosine.h>
+
+using namespace usml::sensors ;
+
+/** Calculates the beam level in de, az, and frequency **/
+void beam_pattern_cosine::beam_level(
+        double de, double az,
+        double pitch, double yaw,
+        const vector<double>& frequencies,
+        vector<double>* level )
+{
+    double _pitch = M_PI_2 + pitch ;
+    double _yaw = M_PI_2 - yaw ;
+    double theta = de + M_PI_2 ;
+    double phi = -az ;
+    double sint = sin( 0.5 * (theta - _pitch) + 1e-10 ) ;
+    double sinp = sin( 0.5 * (phi + _yaw) + 1e-10 ) ;
+    double dotnorm = 1.0 - 2.0 * ( sint * sint
+                     + sin(theta) * sin(_pitch) * sinp * sinp ) ;
+    noalias(*level) =
+            scalar_vector<double>( frequencies.size(), dotnorm ) ;
+}
+
+/**
+ * Initializes the beam pattern
+ */
+void beam_pattern_cosine::directivity_index(
+        const vector<double>& frequencies,
+        vector<double>* level )
+{
+    noalias(*level) =
+            scalar_vector<double>( frequencies.size(), 10.0*log10( 2.0 ) ) ;
+}

--- a/sensors/beam_pattern_cosine.h
+++ b/sensors/beam_pattern_cosine.h
@@ -1,0 +1,65 @@
+/**
+ * @file beam_pattern_cosine.h
+ */
+#pragma once
+
+#include <usml/sensors/beam_pattern_model.h>
+
+namespace usml {
+namespace sensors {
+
+using boost::numeric::ublas::vector ;
+using namespace usml::types ;
+
+/// @ingroup beams
+/// @{
+
+/**
+ * Models a North/South-directional beam pattern. This
+ * pattern can be simulated by a line array with two
+ * elements that are spaced by half the wavelength.
+ *
+ * NOTE: All computation are done in traditional theta and phi
+ * of spherical coordinates. As such all DE, AZ, roll, pitch,
+ * and yaw are transformed before used in computations.
+ */
+class USML_DECLSPEC beam_pattern_cosine : public beam_pattern_model {
+
+    public:
+
+        /**
+         * Constructs a cosine-directional beam pattern.
+         */
+        beam_pattern_cosine() {}
+
+        /**
+         * Computes the response level in a specific DE/AZ pair and
+         * beam steering angle. The return, level, is passed
+         * back in linear units.
+         *
+         * @param de            Depression/Elevation angle (rad)
+         * @param az            Azimuthal angle (rad)
+         * @param pitch         pitch in the DE dimension (rad)
+         * @param yaw           yaw in the AZ dimension (rad)
+         * @param frequencies   list of frequencies to compute beam level for
+         * @param level         beam level for each frequency
+         */
+        virtual void beam_level( double de, double az,
+                                 double pitch, double yaw,
+                                 const vector<double>& frequencies,
+                                 vector<double>* level ) ;
+
+        /**
+         * Directivity index for an cosine-directional beam pattern
+         *
+         * @param frequencies   list of frequencies to compute DI for
+         * @param level         gain for each frequency
+         */
+        virtual void directivity_index( const vector<double>& frequencies,
+                                        vector<double>* level ) ;
+
+};
+
+/// @}
+}   // end of namespace sensors
+}   // end of namespace usml

--- a/sensors/beam_pattern_grid.h
+++ b/sensors/beam_pattern_grid.h
@@ -1,0 +1,325 @@
+/**
+ * @file beam_pattern_grid.h
+ */
+#pragma once
+
+#include <usml/sensors/beam_pattern_model.h>
+#include <usml/types/data_grid.h>
+#include <algorithm>
+
+namespace usml {
+namespace sensors {
+
+using boost::numeric::ublas::vector ;
+using namespace usml::types ;
+
+/// @ingroup beams
+/// @{
+
+/**
+ * A beam pattern function as a mesh or grid beam pattern.
+ */
+template<class T, std::size_t Dim>
+class beam_pattern_grid: public beam_pattern_model, public data_grid<T,Dim> {
+
+    public:
+
+        typedef T               value_type ;
+        typedef T*              value_ptr ;
+        typedef value_ptr*      value_double_ptr ;
+        typedef std::size_t     size_type ;
+        typedef beam_pattern_grid<T,Dim>    self_type ;
+        typedef enum { LINEAR_UNITS, LOG_UNITS }    data_units ;
+
+        /**
+         * Constructs a grid or mesh of beam levels for a beam
+         * pattern. The axes order is dimension zero, frequencies
+         * dimension one, DEs and dimension two, AZs. The data
+         * is passed in as a pointer along with a data_unit.
+         * The construct pattern call then determines how to
+         * interpret the data passed in and adjusts it as needed.
+         *
+         * Once the data grid is constructed, the directivity index
+         * is computed. This uses the analytic definition of
+         * directivity index and then stores these values as a
+         * function of frequency in a separate data_grid.
+         *
+         * @param axes          list of axes for the beam pattern
+         * @param data          pointer to the beam levels
+         * @param data_unit     units that the data are in upon
+         *                      being passed in.
+         */
+        beam_pattern_grid( seq_vector* axes[], const value_ptr data,
+                           const data_units& data_unit )
+            : data_grid<T,Dim>( axes )
+        {
+            construct_pattern( data, data_unit ) ;
+            construct_directivity_grid() ;
+        }
+
+        /**
+         * Destructor
+         */
+        ~beam_pattern_grid() {
+            if( _directivity_index ) {
+                delete _directivity_index ;
+                _directivity_index = NULL ;
+            }
+        }
+
+        /**
+         * Computes the beam level gain along a specific DE and AZ direction.
+         *
+         * @param de            Depression/Elevation angle (rad)
+         * @param az            Azimuthal angle (rad)
+         * @param pitch         pitch in the DE dimension (rad)
+         * @param yaw           yaw in the AZ dimension (rad)
+         * @param frequencies   frequencies to compute beam level for
+         * @param level         beam level for each frequency
+         */
+        virtual void beam_level( double de, double az,
+                                 double pitch, double yaw,
+                                 const vector<double>& frequencies,
+                                 vector<double>* level )
+        {
+            size_type num_freq( frequencies.size() ) ;
+            vector<double> tmp( num_freq, 0.0 ) ;
+            switch( Dim ) {
+
+                /**
+                 * 1-D gridded beam levels
+                 */
+                case 1 :
+                    for(size_type i=0; i<num_freq; ++i) {
+                        value_type freq = frequencies[i] ;
+                        tmp[i] = this->interpolate( &freq ) ;
+                    }
+                    noalias(*level) = tmp ;
+                    break ;
+
+                /**
+                 * 2-D gridded beam levels
+                 */
+				case 2:
+					{
+						value_type location[2];
+						location[1] = de - pitch;
+						for (size_type i = 0; i < num_freq; ++i) {
+							location[0] = frequencies[i];
+							tmp[i] = this->interpolate(location);
+						}
+						noalias(*level) = tmp;
+					}
+                    break ;
+
+                /**
+                 * 3-D gridded beam levels
+                 */
+				case 3:
+					{
+						value_type location[3];
+						location[1] = de - pitch;
+						location[2] = az - yaw;
+						for (size_type i = 0; i < num_freq; ++i) {
+							location[0] = frequencies[i];
+							tmp[i] = this->interpolate(location);
+						}
+						noalias(*level) = tmp;
+					}
+                    break ;
+
+                /**
+                 * Invalid dimension value
+                 */
+                default :
+                    std::invalid_argument(
+                            "beam_pattern_grid must be 1-D, 2-D, or 3-D") ;
+                    break ;
+            }
+        }
+
+        /**
+         * Computes the directivity index for each frequency.
+         */
+        virtual void directivity_index( const vector<double>& frequencies,
+                                        vector<double>* level )
+        {
+            size_type num_freq( frequencies.size() ) ;
+            vector<double> tmp( num_freq, 0.0 ) ;
+            switch( Dim ) {
+
+                /**
+                 * 1-D gridded beam levels
+                 */
+                case 1 :
+                    for(size_type i=0; i<num_freq; ++i) {
+                        value_type freq = frequencies[i] ;
+                        value_type di = _directivity_index->interpolate( &freq ) ;
+                        tmp[i] = 10.0 * log10( di ) ;
+                    }
+                    break ;
+
+                /**
+                 * 2-D gridded beam levels
+                 */
+                case 2 :
+                    for(size_type i=0; i<num_freq; ++i) {
+                        value_type freq = frequencies[i] ;
+                        value_type di = _directivity_index->interpolate( &freq ) ;
+                        tmp[i] = 10.0 * log10( 2.0 / di ) ;
+                    }
+                    break ;
+
+                /**
+                 * 3-D gridded beam levels
+                 */
+                case 3 :
+                    for(size_type i=0; i<num_freq; ++i) {
+                        value_type freq = frequencies[i] ;
+                        value_type di = _directivity_index->interpolate( &freq ) ;
+                        tmp[i] = 10.0 * log10( (4.0*M_PI) / di ) ;
+                    }
+                    break ;
+
+                /**
+                 * Invalid dimension value
+                 */
+                default :
+                    std::invalid_argument(
+                            "beam_pattern_grid must be 1-D, 2-D, or 3-D") ;
+                    break ;
+            }
+            noalias(*level) = tmp ;
+        }
+
+
+    private:
+
+        /**
+         * Data grid that stores the directivity index.
+         */
+        data_grid<double,1>* _directivity_index ;
+
+        /**
+         * Constructs the data grid using the passed in data.
+         */
+        void construct_pattern( const value_ptr data,
+                                const data_units& data_unit )
+        {
+            size_type N = 1 ;
+            for(size_type i=0; i<Dim; ++i) {
+                N *= this->_axis[i]->size() ;
+                this->interp_type( i, GRID_INTERP_PCHIP ) ;
+            }
+            switch( data_unit ) {
+
+                /**
+                 * Data that has been passed in is in log units
+                 * and needs to be converted to linear units
+                 */
+                case LOG_UNITS :
+                {
+                    value_ptr data_copy = new value_type[N] ;
+                    memcpy( data_copy, data, N*sizeof(value_type) ) ;
+                    for(size_type i=0; i<N; ++i) {
+                        *(data_copy++) = std::pow( 10.0, (-(*data_copy)/10.0) ) ;
+                    }
+                    memcpy( this->_data, data_copy, N*sizeof(value_type) ) ;
+                    delete data_copy ;
+                    break ;
+                }
+
+                /**
+                 * The data was already passed to this constructor in
+                 * linear units.
+                 */
+                default:
+                    memcpy( this->_data, data, N*sizeof(value_type) ) ;
+                    break ;
+            }
+            memset( this->_edge_limit, true, Dim*sizeof(bool) ) ;
+        }
+
+       /**
+        * Computes the directivity index by summing all beam
+        * level contributions for each frequency along every
+        * DE and AZ. Stores the gird locally to be used
+        * on call.
+        */
+       void construct_directivity_grid() {
+           size_type num_freq( this->_axis[0]->size() ) ;
+           seq_vector* axes[] = { this->axis(0) } ;
+           _directivity_index = new data_grid<double,1>( axes ) ;
+           value_ptr p_data = _directivity_index->data() ;
+           for(size_type i=0; i<num_freq; ++i) {
+               sum_data( i, *(p_data++) ) ;
+           }
+       }
+
+       /**
+        * Adds all intensities for a specific frequency.
+        *
+        * @param index      Index for the frequency of interest
+        * @return           The summation of all intensities for
+        *                   this frequency
+        */
+       void sum_data( const size_type index, value_type& total )
+       {
+           total = 0.0 ;
+           switch( Dim ) {
+
+               /**
+                * 1-D grid of data points
+                */
+               case 1 :
+                   total = this->_data[index] ;
+                   break ;
+
+               /**
+                * 2-D grid of data points
+                */
+               case 2 :
+               {
+                   size_type num_de( this->_axis[1]->size() ) ;
+                   seq_vector* theta = this->_axis[1] ;
+                   for(size_type i=0; i<num_de; ++i) {
+                       total += this->_data[index*num_de+i] * cos( (*theta)[i] )
+                                * theta->increment(i) ;
+                   }
+                   break ;
+               }
+
+               /**
+                * 3-D grid of data points
+                */
+               case 3 :
+               {
+                   size_type num_de( this->_axis[1]->size() ) ;
+                   seq_vector* theta = this->_axis[1] ;
+                   size_type num_az( this->_axis[2]->size() ) ;
+                   seq_vector* phi = this->_axis[2] ;
+                   for(size_type i=0; i<num_de; ++i) {
+                       for(size_type j=0; j<num_az; ++j) {
+                           size_type tmp = j + num_az * (i + num_de*index) ;
+                           total += this->_data[tmp] * cos( (*theta)[i] )
+                                   * theta->increment(i) * phi->increment(j) ;
+                       }
+                   }
+                   break ;
+               }
+
+               /**
+                * Invalid dimension value
+                */
+               default:
+                   std::invalid_argument(
+                           "beam_pattern_grid must be 1-D, 2-D, or 3-D") ;
+                   break ;
+           }
+       }
+
+};
+
+/// @}
+}   // end of namespace sensors
+}   // end of namespace usml

--- a/sensors/beam_pattern_grid.h
+++ b/sensors/beam_pattern_grid.h
@@ -260,6 +260,7 @@ class beam_pattern_grid: public beam_pattern_model, public data_grid<T,Dim> {
         * Adds all intensities for a specific frequency.
         *
         * @param index      Index for the frequency of interest
+        * @param total      Reference to return the total values
         * @return           The summation of all intensities for
         *                   this frequency
         */

--- a/sensors/beam_pattern_line.cc
+++ b/sensors/beam_pattern_line.cc
@@ -1,0 +1,73 @@
+/**
+ * @file beam_pattern_line.cc
+ */
+
+#include <usml/sensors/beam_pattern_line.h>
+
+using namespace usml::sensors ;
+
+/** Calculates the beam level in de, az, and frequency **/
+void beam_pattern_line::beam_level(
+        double de, double az,
+        double pitch, double yaw,
+        const vector<double>& frequencies,
+        vector<double>* level )
+{
+    double _pitch ;
+    double _yaw ;
+    switch( _axis ) {
+        case HORIZONTAL :
+            _pitch = -(pitch + M_PI_2) ;
+            _yaw = -yaw ;
+            break ;
+        default :
+            _pitch = -pitch ;
+            _yaw = -yaw ;
+            break ;
+    }
+    double theta = de + M_PI_2 ;
+    double phi = -az ;
+    double sint = sin( 0.5 * (theta - _pitch) + 1e-10 ) ;
+    double sinp = sin( 0.5 * (phi + _yaw) + 1e-10 ) ;
+    double dotnorm = 1.0 - 2.0 * ( sint * sint
+                     + sin(theta) * sin(_pitch) * sinp * sinp ) ;
+    noalias(*level) = element_prod(
+                element_div( sin(frequencies*_omega_n*dotnorm - frequencies*_steering_n),
+                    _n*sin(frequencies*_omega*dotnorm - frequencies*_steering) ),
+                element_div( sin(frequencies*_omega_n*dotnorm - frequencies*_steering_n),
+                    _n*sin(frequencies*_omega*dotnorm - frequencies*_steering) )
+            ) ;
+}
+
+/**
+ * Initializes the beam pattern
+ */
+void beam_pattern_line::initialize_beams(
+        double sound_speed, double spacing,
+        double steering_angle )
+{
+        // compute omega/2 and omega/2 * n
+    _omega = (M_PI * spacing / sound_speed) ;
+    _omega_n = _omega * _n ;
+        // compute sine of the steering angles and multiply by omega and n
+    _steering = _omega * sin(steering_angle) ;
+    _steering_n = _n * _steering ;
+}
+
+/**
+ * Computes the directivity index for a list of
+ * frequencies.
+ */
+void beam_pattern_line::directivity_index(
+        const vector<double>& frequencies,
+        vector<double>* level )
+{
+    vector<double> di( frequencies.size(), 0.0 ) ;
+    vector<double> steer_plus = 2.0*(_omega+_steering)*frequencies ;
+    vector<double> steer_minus = 2.0*(_omega-_steering)*frequencies ;
+    for(size_t p=1; p<_n; ++p) {
+        di += element_div( (_n-p)*(sin(p*steer_plus)+sin(p*steer_minus)),
+                                           (p*2.0*_omega*frequencies) ) ;
+    }
+    noalias(*level) = 10.0*log10( _n ) - 10.0*log10( 1.0 + (1.0/_n)*di ) ;
+}

--- a/sensors/beam_pattern_line.h
+++ b/sensors/beam_pattern_line.h
@@ -42,7 +42,7 @@ class USML_DECLSPEC beam_pattern_line : public beam_pattern_model {
          * @param sound_speed       speed of sound in water at the array
          * @param spacing           distance between each element on the array
          * @param elements          number of elements on the line array
-         * @param steering_angles   list of steering angles relative to the
+         * @param steering_angle    list of steering angles relative to the
          *                          reference axis
          * @param axis              the reference axis of the array.
          */
@@ -71,7 +71,6 @@ class USML_DECLSPEC beam_pattern_line : public beam_pattern_model {
          * @param az            Azimuthal angle (rad)
          * @param pitch         pitch in the DE dimension (rad)
          * @param yaw           yaw in the AZ dimension (rad)
-         * @param beam          beam steering to find response level (size_t)
          * @param frequencies   frequencies to compute beam level for
          * @param level         beam level for each frequency
          */

--- a/sensors/beam_pattern_line.h
+++ b/sensors/beam_pattern_line.h
@@ -1,0 +1,131 @@
+/**
+ * @file beam_pattern_line.h
+ */
+#pragma once
+
+#include <usml/sensors/beam_pattern_model.h>
+
+namespace usml {
+namespace sensors {
+
+using boost::numeric::ublas::vector ;
+using namespace usml::types ;
+
+/// @ingroup beams
+/// @{
+
+/**
+ * Models a beam pattern constructed from an array of elements
+ * that are linearly oriented and spaced apart along the array's
+ * major axis.
+ *
+ * NOTE: All computation are done in traditional theta and phi
+ * of spherical coordinates. As such all DE, AZ, roll, pitch,
+ * and yaw are transformed before used in computations.
+ */
+class USML_DECLSPEC beam_pattern_line : public beam_pattern_model {
+
+    public:
+
+        /**
+         * Type of linear array
+         * Specifies which axis is the reference axis of
+         * the array. Vertical being in the z-direction
+         * spatially and horizontal being in the xy-planar
+         * direction.
+         */
+        typedef enum { VERTICAL, HORIZONTAL } reference_axis ;
+
+        /**
+         * Constructs a beam pattern for a linear array.
+         *
+         * @param sound_speed       speed of sound in water at the array
+         * @param spacing           distance between each element on the array
+         * @param elements          number of elements on the line array
+         * @param steering_angles   list of steering angles relative to the
+         *                          reference axis
+         * @param axis              the reference axis of the array.
+         */
+        beam_pattern_line( double sound_speed, double spacing,
+                           size_t elements, double steering_angle,
+                           reference_axis axis=VERTICAL ) : _axis(axis)
+        {
+            switch( _axis ) {
+                case HORIZONTAL :
+                    _n = elements ;
+                    initialize_beams( sound_speed, spacing, (steering_angle + M_PI_2) ) ;
+                    break ;
+                default :
+                    _n = elements ;
+                    initialize_beams( sound_speed, spacing, steering_angle ) ;
+                    break ;
+            }
+        }
+
+        /**
+         * Computes the response level in a specific DE/AZ pair and
+         * beam steering angle. The return, level, is passed
+         * back in linear units.
+         *
+         * @param de            Depression/Elevation angle (rad)
+         * @param az            Azimuthal angle (rad)
+         * @param pitch         pitch in the DE dimension (rad)
+         * @param yaw           yaw in the AZ dimension (rad)
+         * @param beam          beam steering to find response level (size_t)
+         * @param frequencies   frequencies to compute beam level for
+         * @param level         beam level for each frequency
+         */
+        virtual void beam_level( double de, double az,
+                                 double pitch, double yaw,
+                                 const vector<double>& frequencies,
+                                 vector<double>* level ) ;
+
+        /**
+         * Computes the directivity index for a list of frequencies
+         *
+         * @param frequencies   frequencies to determine DI at
+         * @param level         gain for the provided frequencies
+         */
+        virtual void directivity_index( const vector<double>& frequencies,
+                                        vector<double>* level ) ;
+
+    protected:
+
+        /**
+         * Number of elements on the linear array
+         */
+        size_t _n ;
+
+        /**
+         * Local cache of commonly computed values
+         * for frequency computations.
+         */
+        double _omega ;
+        double _omega_n ;
+
+        /**
+         * Local cache of commonly computed
+         * using the steering angles
+         */
+        double _steering ;
+        double _steering_n ;
+
+        /**
+         * Defines the reference axis for this linear array's beam
+         * pattern.
+         */
+        reference_axis _axis ;
+
+        /**
+         * Initializes the beam pattern. To save execution time, common computations
+         * are done and stored locally to be used at a later time.
+         */
+        void initialize_beams( double sound_speed,
+                               double spacing,
+                               double steering_angle ) ;
+
+};
+
+/// @}
+}   // end of namespace sensors
+}   // end of namespace usml

--- a/sensors/beam_pattern_model.h
+++ b/sensors/beam_pattern_model.h
@@ -69,7 +69,7 @@ class USML_DECLSPEC beam_pattern_model {
         /**
          * Accesor to the directivity index
          *
-         * @param freqeuncies    list of frequencies
+         * @param frequencies    list of frequencies
          * @param level          directivity index for these frequency
          */
         virtual void directivity_index( const vector<double>& frequencies,

--- a/sensors/beam_pattern_model.h
+++ b/sensors/beam_pattern_model.h
@@ -1,0 +1,87 @@
+/**
+ *  @file beam_pattern_model.h
+ *  Generic interface for beam patterning
+ */
+#pragma once
+
+#include <boost/numeric/ublas/vector_expression.hpp>
+#include <usml/types/types.h>
+
+namespace usml {
+namespace sensors {
+
+using boost::numeric::ublas::vector ;
+using namespace usml::types ;
+
+/// @ingroup beams
+/// @{
+
+/**
+ * A "beam pattern" computes the gain for an incident wave as a function
+ * of incident angles, beam steering angle, and frequency.
+ *
+ * This class implements an abstract function used to compute both
+ * the directivity index of the array and the beam level gain.
+ *
+ * A beam pattern function is constructed based on the physical spacing
+ * of the elements and the wavelength of the incident acoustic energy.
+ * This function is then used to compute the array gain in the specific
+ * direction of an incident acoustic wave.
+ *
+ * When the signal is a unidirectional plane wave, hence perfectly coherent,
+ * and when the noise is isotropic, the array gain reduces to the
+ * directivity index.
+ *
+ * @xref R.J. Urick, Principles of Underwater Sound, 3rd Edition,
+ * (1983), p. 42.
+ *
+ * Many properties of the beam patterns depend on predetermined values.
+ * Such as the beam steering angles, frequency spectrum, and physical
+ * arrangement of the elements. Using these, many variables can be
+ * pre-computed and cached locally to reduce computation time.
+ */
+class USML_DECLSPEC beam_pattern_model {
+
+    public:
+
+        /**
+         * Computes the beam level gain along a specific DE and AZ direction
+         * for a specific beam steering angle. The DE and AZ are passed in as
+         * Eta/VarPhi values and then transformed to a theta/phi equivalent
+         * that are used for computation.
+         *
+         * NOTE: The choice of return in linear units
+         * is a development choice and may be changed depending on how
+         * this value is used in the final release state.
+         *
+         * @param de            Depression/Elevation angle (rad)
+         * @param az            Azimuthal angle (rad)
+         * @param pitch         pitch in the DE dimension (rad)
+         * @param yaw           yaw in the AZ dimension (rad)
+         * @param frequencies   list of frequencies to compute beam level for
+         * @param level         beam level for each frequency
+         */
+        virtual void beam_level( double de, double az,
+                                 double pitch, double yaw,
+                                 const vector<double>& frequencies,
+                                 vector<double>* level ) = 0 ;
+
+        /**
+         * Accesor to the directivity index
+         *
+         * @param freqeuncies    list of frequencies
+         * @param level          directivity index for these frequency
+         */
+        virtual void directivity_index( const vector<double>& frequencies,
+                                        vector<double>* level ) = 0 ;
+
+        /**
+         * Destructor
+         */
+        virtual ~beam_pattern_model() {}
+
+};
+
+/// @}
+}   // end of namespace sensors
+}   // end of namespace usml

--- a/sensors/beam_pattern_omni.cc
+++ b/sensors/beam_pattern_omni.cc
@@ -1,0 +1,28 @@
+/**
+ * @file beam_pattern_omni.cc
+ */
+
+#include <usml/sensors/beam_pattern_omni.h>
+
+using namespace usml::sensors ;
+
+/** Calculates the beam level in de, az, and frequency **/
+void beam_pattern_omni::beam_level(
+        double de, double az,
+        double pitch, double yaw,
+        const vector<double>& frequencies,
+        vector<double>* level )
+{
+    noalias(*level) = scalar_vector<double>( frequencies.size(), 1.0 ) ;
+}
+
+/**
+ * The user may call this function but it has no effect on the
+ * beam level.
+ */
+void beam_pattern_omni::directivity_index(
+        const vector<double>& frequencies,
+        vector<double>* level )
+{
+    noalias(*level) = scalar_vector<double>( frequencies.size(), 0.0 ) ;
+}

--- a/sensors/beam_pattern_omni.h
+++ b/sensors/beam_pattern_omni.h
@@ -1,0 +1,59 @@
+/**
+ * @file beam_pattern_omni.h
+ */
+#pragma once
+
+#include <usml/sensors/beam_pattern_model.h>
+
+namespace usml {
+namespace sensors {
+
+using boost::numeric::ublas::vector ;
+using namespace usml::types ;
+
+/// @ingroup beams
+/// @{
+
+/**
+ * Models an omni-directional beam pattern.
+ */
+class USML_DECLSPEC beam_pattern_omni : public beam_pattern_model {
+
+    public:
+
+        /**
+         * Constructors an omni-directional beam pattern.
+         */
+        beam_pattern_omni() {}
+
+        /**
+         * Computes the response level in a specific DE/AZ pair and
+         * beam steering angle. The return, level, is passed
+         * back in linear units.
+         *
+         * @param de            Depression/Elevation angle (rad)
+         * @param az            Azimuthal angle (rad)
+         * @param pitch         pitch in the DE dimension (rad)
+         * @param yaw           yaw in the AZ dimension (rad)
+         * @param freuencies    list of frequencies to compute beam level for
+         * @param level         beam level for each frequency
+         */
+        virtual void beam_level( double de, double az,
+                                 double pitch, double yaw,
+                                 const vector<double>& frequencies,
+                                 vector<double>* level ) ;
+
+        /**
+         * Directivity index for an omni-directional beam pattern
+         * The gain for this type of beam pattern is 0 dB.
+         *
+         * @param frequencies   list of frequencies to compute DI for
+         * @param level         gain for each frequency
+         */
+        virtual void directivity_index( const vector<double>& frequencies,
+                                        vector<double>* level ) ;
+};
+
+/// @}
+}   // end of namespace sensors
+}   // end of namespace usml

--- a/sensors/beam_pattern_omni.h
+++ b/sensors/beam_pattern_omni.h
@@ -35,7 +35,7 @@ class USML_DECLSPEC beam_pattern_omni : public beam_pattern_model {
          * @param az            Azimuthal angle (rad)
          * @param pitch         pitch in the DE dimension (rad)
          * @param yaw           yaw in the AZ dimension (rad)
-         * @param freuencies    list of frequencies to compute beam level for
+         * @param frequencies    list of frequencies to compute beam level for
          * @param level         beam level for each frequency
          */
         virtual void beam_level( double de, double az,

--- a/sensors/beam_pattern_sine.cc
+++ b/sensors/beam_pattern_sine.cc
@@ -1,0 +1,36 @@
+/**
+ * @file beam_pattern_sine.cc
+ */
+
+#include <usml/sensors/beam_pattern_sine.h>
+
+using namespace usml::sensors ;
+
+/** Calculates the beam level in de, az, and frequency **/
+void beam_pattern_sine::beam_level(
+        double de, double az,
+        double pitch, double yaw,
+        const vector<double>& frequencies,
+        vector<double>* level )
+{
+    double _pitch = pitch + M_PI_2 ;
+    double theta = de + M_PI_2 ;
+    double phi = -az ;
+    double sint = sin( 0.5 * (theta - _pitch) + 1e-10 ) ;
+    double sinp = sin( 0.5 * (phi + yaw) + 1e-10 ) ;
+    double dotnorm = 1.0 - 2.0 * ( sint * sint
+                     + sin(theta) * sin(_pitch) * sinp * sinp ) ;
+    noalias(*level) =
+            scalar_vector<double>( frequencies.size(), dotnorm ) ;
+}
+
+/**
+ * Computes the directivity index
+ */
+void beam_pattern_sine::directivity_index(
+        const vector<double>& frequencies,
+        vector<double>* level )
+{
+    noalias(*level) =
+            scalar_vector<double>( frequencies.size(), 10.0*log10( 2.0 ) ) ;
+}

--- a/sensors/beam_pattern_sine.h
+++ b/sensors/beam_pattern_sine.h
@@ -1,0 +1,65 @@
+/**
+ * @file beam_pattern_sine.h
+ */
+#pragma once
+
+#include <usml/sensors/beam_pattern_model.h>
+
+namespace usml {
+namespace sensors {
+
+using boost::numeric::ublas::vector ;
+using namespace usml::types ;
+
+/// @ingroup beams
+/// @{
+
+/**
+ * Models a East/West-directional beam pattern. This
+ * pattern can be simulated by a line array with two
+ * elements that are spaced by half the wavelength.
+ *
+ * NOTE: All computation are done in traditional theta and phi
+ * of spherical coordinates. As such all DE, AZ, roll, pitch,
+ * and yaw are transformed before used in computations.
+ */
+class USML_DECLSPEC beam_pattern_sine : public beam_pattern_model {
+
+    public:
+
+        /**
+         * Constructs a sine-directional beam pattern.
+         */
+        beam_pattern_sine() {}
+
+        /**
+         * Computes the response level in a specific DE/AZ pair and
+         * beam steering angle. The return, level, is passed
+         * back in linear units.
+         *
+         * @param de            Depression/Elevation angle (rad)
+         * @param az            Azimuthal angle (rad)
+         * @param pitch         pitch in the DE dimension (rad)
+         * @param yaw           yaw in the AZ dimension (rad)
+         * @param frequencies   list of frequencies to compute beam level for
+         * @param level         beam level for each frequency
+         */
+        virtual void beam_level( double de, double az,
+                                 double pitch, double yaw,
+                                 const vector<double>& frequencies,
+                                 vector<double>* level ) ;
+
+        /**
+         * Directivity index for an sine-directional beam pattern
+         *
+         * @param frequencies   list of frequencies to compute DI for
+         * @param level         gain for each frequency
+         */
+        virtual void directivity_index( const vector<double>& frequencies,
+                                        vector<double>* level ) ;
+
+};
+
+/// @}
+}   // end of namespace sensors
+}   // end of namespace usml

--- a/sensors/beam_pattern_solid.cc
+++ b/sensors/beam_pattern_solid.cc
@@ -1,0 +1,50 @@
+/**
+ * @file beam_pattern_solid.cc
+ */
+
+#include <usml/sensors/beam_pattern_solid.h>
+
+using namespace usml::sensors ;
+
+/** Calculates the beam level in de, az, and frequency **/
+void beam_pattern_solid::beam_level(
+        double de, double az,
+        double pitch, double yaw,
+        const vector<double>& frequencies,
+        vector<double>* level )
+{
+    double up = _max_de - pitch ;
+    double down = _min_de - pitch ;
+    double left = _min_az + yaw ;
+    double right = _max_az + yaw ;
+    vector<double> result = scalar_vector<double>( frequencies.size(), 0.0 ) ;
+    if( (de <= up) && (de >= down) ) {
+        if( (az <= right) && (az >= left) ) {
+            result = scalar_vector<double>( frequencies.size(), 1.0 ) ;
+        }
+    }
+    noalias(*level) = result ;
+}
+
+/**
+ * Computes the directivity index
+ */
+void beam_pattern_solid::directivity_index(
+        const vector<double>& frequencies,
+        vector<double>* level )
+{
+    noalias(*level) =
+            scalar_vector<double>( frequencies.size(), _directivity_index ) ;
+}
+/**
+ * Initializes the beam pattern
+ */
+void beam_pattern_solid::initialize_beam()
+{
+    _max_de *= M_PI / 180.0 ;
+    _min_de *= M_PI / 180.0 ;
+    _max_az *= M_PI / 180.0 ;
+    _min_az *= M_PI / 180.0 ;
+    double solid = (_max_az - _min_az)*(sin(_max_de) - sin(_min_de)) ;
+    _directivity_index = 10.0*log10( (4.0*M_PI) / solid ) ;
+}

--- a/sensors/beam_pattern_solid.h
+++ b/sensors/beam_pattern_solid.h
@@ -1,0 +1,97 @@
+/**
+ * @file beam_pattern_solid.h
+ */
+#pragma once
+
+#include <usml/sensors/beam_pattern_model.h>
+
+namespace usml {
+namespace sensors {
+
+using boost::numeric::ublas::vector ;
+using namespace usml::types ;
+
+/// @ingroup beams
+/// @{
+
+/**
+ * Models a beam pattern that has a maximum response of one
+ * in a specific solid angle and zero everywhere else.
+ *
+ * NOTE: The reference axis for this beam pattern is
+ * in the zero DE direction. As such no transformations
+ * are necessary prior to computation.
+ */
+class USML_DECLSPEC beam_pattern_solid : public beam_pattern_model {
+
+    public:
+
+        /**
+         * Constructs a solid-angle beam pattern.
+         * DE \elem [-90.0 90.0], AZ \elem [0.0 360.0]
+         *
+         * @param max_de        maximum DE of the solid angle (deg)
+         * @param min_de        minimum DE of the solid angle (deg)
+         * @param max_az        maximum AZ of the solid angle (deg)
+         * @param min_az        minimum AZ of the solid angle (deg)
+         */
+        beam_pattern_solid( double max_de, double min_de,
+                            double max_az, double min_az )
+            : _max_de(max_de), _min_de(min_de),
+              _max_az(max_az), _min_az(min_az)
+        {
+            initialize_beam() ;
+        }
+
+        /**
+         * Computes the response level in a specific DE/AZ pair and
+         * beam steering angle. The return, level, is passed
+         * back in linear units.
+         *
+         * @param de            Depression/Elevation angle (rad)
+         * @param az            Azimuthal angle (rad)
+         * @param pitch         pitch in the DE dimension (rad)
+         * @param yaw           yaw in the AZ dimension (rad)
+         * @param frequencies   list of frequencies to compute beam level for
+         * @param level         beam level for each frequency
+         */
+        virtual void beam_level( double de, double az,
+                                 double pitch, double yaw,
+                                 const vector<double>& frequencies,
+                                 vector<double>* level ) ;
+
+        /**
+         * Directivity index for a beam pattern of solid angle.
+         *
+         * @param frequencies   list of frequencies to compute DI for
+         * @param level         gain for each frequency
+         */
+        virtual void directivity_index( const vector<double>& frequencies,
+                                        vector<double>* level ) ;
+
+    protected:
+
+        /**
+         * Directivity index of this beam pattern
+         */
+        double _directivity_index ;
+
+        /**
+         * Solid angle information
+         */
+        double _max_de ;
+        double _min_de ;
+        double _max_az ;
+        double _min_az ;
+
+        /**
+         * The directivity index array size to frequencies size and
+         * zero.
+         */
+        void initialize_beam() ;
+
+};
+
+/// @}
+}   // end of namespace sensors
+}   // end of namespace usml

--- a/sensors/beams.h
+++ b/sensors/beams.h
@@ -1,0 +1,23 @@
+/**
+ * @file beams.h Beam Pattern Models
+ * @defgroup beams Beam Pattern Models
+ *
+ * This package defines the beam pattern models provided by USML.
+ *
+ * @defgroup beams_test Regression Tests
+ * @ingroup beams
+ *
+ * Regression tests for the beams package
+ */
+#pragma once
+
+#include <usml/sensors/beam_pattern_model.h>
+
+#include <usml/sensors/beam_pattern_omni.h>
+#include <usml/sensors/beam_pattern_cosine.h>
+#include <usml/sensors/beam_pattern_sine.h>
+
+#include <usml/sensors/beam_pattern_line.h>
+#include <usml/sensors/beam_pattern_solid.h>
+
+#include <usml/sensors/beam_pattern_grid.h>

--- a/sensors/test/beam_pattern_test.cc
+++ b/sensors/test/beam_pattern_test.cc
@@ -1,0 +1,550 @@
+/*
+ * @examples sensors/test/beam_pattern_test.cc
+ */
+
+#include <boost/test/unit_test.hpp>
+#include <usml/sensors/beams.h>
+#include <fstream>
+#include <cstdlib>
+#include <ctime>
+
+BOOST_AUTO_TEST_SUITE(beam_pattern_test)
+
+using namespace boost::unit_test ;
+using namespace usml::sensors ;
+
+/**
+ * @ingroup beams_test
+ * @{
+ */
+
+/**
+ * Test the functionality of the omni-directional
+ * beam pattern class. The beam_level should always be 1.0
+ * and directivity index should be 0 dB.
+ *
+ * A check for the directivity index, as computed
+ * using a Simpson's rule approximation, fails if it
+ * is different from zero by 0.02 dB or more.
+ */
+BOOST_AUTO_TEST_CASE( omni_pattern_test ) {
+    cout << "=== beam_pattern_test/omni_pattern_test ===" << endl ;
+    vector<double> freq( 1, 900.0 ) ;
+    beam_pattern_omni omni ;
+
+    vector<double> level( freq.size(), 0.0 ) ;
+    double total = 0 ;
+    for(int az=0; az<=360; ++az) {
+        for(int de=-90; de<=90; ++de) {
+            double de_rad = de * M_PI/180.0 ;
+            double az_rad = az * M_PI/180.0 ;
+            omni.beam_level( de_rad, az_rad, 0, 0, freq, &level ) ;
+            total += level(0)*cos(de_rad)*(M_PI/180.0)*(M_PI/180.0) ;
+            BOOST_CHECK_EQUAL( level(0), 1.0 ) ;
+        }
+    }
+
+    total = 10.0 * log10( (4.0*M_PI) / total ) ;
+    omni.directivity_index( freq, &level ) ;
+    cout << "Directivity index: " << total << endl ;
+    BOOST_CHECK_SMALL( level(0)-total, 0.02 ) ;
+
+}
+
+/**
+ * Test the functionality of the sine-directional
+ * beam pattern class. The beam_level should have a maximum
+ * response in the East and West directions.
+ *
+ * This test fails if the maximum response axis differs from
+ * the North (AZ=90) and South (AZ=270) directions. Also,
+ * if the directivity index, as computed using a Simpson's
+ * rule approximation, is different from the analytic solution
+ * by 1% the test fails.
+ */
+BOOST_AUTO_TEST_CASE( sine_pattern_test ) {
+    cout << "=== beam_pattern_test/sine_pattern_test ===" << endl ;
+    const char* csvname = USML_TEST_DIR "/sensors/test/beam_pattern_sine.csv" ;
+    vector<double> freq( 1, 900.0 ) ;
+    beam_pattern_sine sine ;
+
+    int pitch = 62 ;
+    int yaw = 31 ;
+    double d2r = M_PI / 180.0 ;
+
+    std::ofstream of( csvname ) ;
+    cout << "Saving beam data to " << csvname << endl ;
+    vector<double> level( freq.size(), 0.0 ) ;
+    double total = 0.0 ;
+    for(int az=0; az<=360; ++az) {
+        for(int de=-90; de<=90; ++de) {
+            double de_rad = de * d2r ;
+            double az_rad = az * d2r ;
+            sine.beam_level( de_rad, az_rad, pitch*d2r, yaw*d2r, freq, &level ) ;
+            of << level(0) ;
+            if( de!=90 ) of << "," ;
+            total += abs(level(0))*cos(de_rad)*(M_PI/180.0)*(M_PI/180.0) ;
+            if( (az==yaw && de==pitch) || (az==(180+yaw) && de==-pitch) )
+                BOOST_CHECK_CLOSE( abs(level(0)), 1.0, 0.2 ) ;
+        }
+        of << endl ;
+    }
+    total = 10.0*log10( (4*M_PI) / total ) ;
+    sine.directivity_index( freq, &level ) ;
+    cout << "Directivity index" << endl ;
+    cout << "analytic: " << level(0) << "\napproximation: " << total << endl ;
+    BOOST_CHECK_CLOSE( level(0), total, 1.0 ) ;
+
+}
+
+/**
+ * Test the functionality of the cosine-directional
+ * beam pattern class. The beam_level should have a maximum
+ * response in the North and South directions.
+ *
+ * This test fails if the maximum response axis differs from
+ * the East (AZ=0) and West (AZ=180) directions. Also,
+ * if the directivity index, as computed using a Simpson's
+ * rule approximation, is different from the analytic solution
+ * by 1% the test fails.
+ */
+BOOST_AUTO_TEST_CASE( cosine_pattern_test ) {
+    cout << "=== beam_pattern_test/cosine_pattern_test ===" << endl ;
+    const char* csvname = USML_TEST_DIR "/sensors/test/beam_pattern_cosine.csv" ;
+    vector<double> freq( 1, 900.0 ) ;
+    beam_pattern_cosine cosine ;
+
+    int pitch = 21 ;
+    int yaw = 57 ;
+    double d2r = M_PI / 180.0 ;
+
+    std::ofstream of( csvname ) ;
+    cout << "Saving beam data to " << csvname << endl ;
+    vector<double> level( freq.size(), 0.0 ) ;
+    double total = 0.0 ;
+    for(int az=0; az<=360; ++az) {
+        for(int de=-90; de<=90; ++de) {
+            double de_rad = de * d2r ;
+            double az_rad = az * d2r ;
+            cosine.beam_level( de_rad, az_rad, pitch*d2r, yaw*d2r, freq, &level ) ;
+            of << level(0) ;
+            if( de!=90 ) of << "," ;
+            total += abs(level(0))*cos(de_rad)*(M_PI/180.0)*(M_PI/180.0) ;
+            if( (az==(270-yaw) && de==-pitch) || (az==(90-yaw) && de==pitch) )
+                BOOST_CHECK_CLOSE( abs(level(0)), 1.0, 0.2 ) ;
+        }
+        of << endl ;
+    }
+    total = 10.0*log10( (4*M_PI) / total ) ;
+    cosine.directivity_index( freq, &level ) ;
+    cout << "Directivity index" << endl ;
+    cout << "analytic: " << level(0) << "\napproximation: " << total << endl ;
+    BOOST_CHECK_CLOSE( level(0), total, 1.0 ) ;
+
+}
+
+/**
+ * Test the basic features of the beam_pattern_model using
+ * a vertical array of elements model. Data is save to a
+ * file and support matlab code is provided to verify the
+ * spatial orientation of the beam pattern is correct.
+ *
+ * The test fails if either the following are false:
+ *
+ *  - The main lobe is in the correct is not in the correct
+ *    direction. If the maximum response is not in the
+ *    correct direction, the beam level will differ from
+ *    1.0 by greater than 1e-4%
+ *  - The Directivity index is also differs from a
+ *    a Simpson's rule integration approximation of
+ *    directivity index from beam level, by more than
+ *    1.0%.
+ */
+BOOST_AUTO_TEST_CASE( vertical_array_test ) {
+    cout << "===== beam_pattern_test/vertical_array_test =====" << endl ;
+    const char* envname = USML_TEST_DIR "/sensors/test/vertical_array_parameters.csv" ;
+    const char* csvname = USML_TEST_DIR "/sensors/test/vertical_array_beam_pattern.csv" ;
+
+    // Physical and Environmental parameters concerning the array
+    double c0 = 1500.0 ;
+    double d = 0.75 ;
+    double n = 5 ;
+    double steering = M_PI/32.0 ;
+    vector<double> freq( 1, 900.0 ) ;
+
+    beam_pattern_line array( c0, d, n, steering ) ;
+
+    double pitch = 35.0 * M_PI/180.0 ;
+    double yaw = 45.0 * M_PI/180.0 ;
+
+    std::ofstream of( csvname ) ;
+    cout << "Saving beam data to " << csvname << endl ;
+    vector<double> level( freq.size(), 0.0 ) ;
+    double total = 0 ;
+    for(int az=0; az<=360; ++az) {
+        for(int de=-90; de<=90; ++de) {
+            double de_rad = de * M_PI/180.0 ;
+            double az_rad = az * M_PI/180.0 ;
+            array.beam_level( de_rad, az_rad, pitch, yaw, freq, &level ) ;
+            of << level(0) ;
+            if( de!=90 ) of << "," ;
+            total += level(0)*cos(de_rad)*(M_PI/180.0)*(M_PI/180.0) ;
+        }
+        of << endl ;
+    }
+
+    // check that the main lobe is at the correct position
+    array.beam_level( -(pitch+steering), -yaw, pitch, yaw, freq, &level ) ;
+    BOOST_CHECK_CLOSE( level(0), 1.0, 1e-4 ) ;
+
+    std::ofstream ef( envname ) ;
+    cout << "Saving environmental and array parameters to " << envname << endl ;
+    ef << "c0,d,n,roll,pitch,yaw,steering,freq" << endl ;
+    ef << c0 << ","
+       << d << ","
+       << n << ","
+       << pitch << ","
+       << yaw << ","
+       << steering << "," ;
+    for(int i=0; i<freq.size(); ++i) {
+        ef << freq(i) ;
+        if( i != freq.size()-1 ) ef << "," ;
+    }
+    ef << endl ;
+
+    total = 10.0*log10( (4*M_PI)/total ) ;
+    array.directivity_index( freq, &level ) ;
+    cout << "Directivity index" << endl ;
+    cout << "analytic: " << level(0) << "\napproximation: " << total << endl ;
+    BOOST_CHECK_CLOSE( level(0), total, 1.0 ) ;
+}
+
+/**
+ * Test the basic features of the beam_pattern_model using
+ * a horizontal array of elements model. Data is save to a
+ * file and support matlab code is provided to verify the
+ * spatial orientation of the beam pattern is correct.
+ *
+ * The test fails if either the following are false:
+ *
+ *  - The main lobe is in the correct is not in the correct
+ *    direction. If the maximum response is not in the
+ *    correct direction, the beam level will differ from
+ *    1.0 by greater than 1e-4%
+ *  - The Directivity index is also differs from a
+ *    a Simpson's rule integration approximation of
+ *    directivity index from beam level, by more than
+ *    1.0%.
+ */
+BOOST_AUTO_TEST_CASE( horizontal_array_test ) {
+    cout << "===== beam_pattern_test/horizontal_array_test =====" << endl ;
+    const char* envname = USML_TEST_DIR "/sensors/test/horizontal_array_parameters.csv" ;
+    const char* csvname = USML_TEST_DIR "/sensors/test/horizontal_array_beam_pattern.csv" ;
+
+    // Physical and Environmental parameters concerning the array
+    double c0 = 1500.0 ;
+    double d = 0.75 ;
+    double n = 5 ;
+    double steering = M_PI/4.0 ;
+    vector<double> freq( 1, 900.0 ) ;
+
+    beam_pattern_line array( c0, d, n, steering, beam_pattern_line::HORIZONTAL ) ;
+
+    double pitch = 45.0 * M_PI/180.0 ;
+    double yaw = 45.0 * M_PI/180.0 ;
+
+    std::ofstream of( csvname ) ;
+    cout << "Saving beam data to " << csvname << endl ;
+    vector<double> level( freq.size(), 0.0 ) ;
+    double total = 0 ;
+    for(int az=0; az<=360; ++az) {
+        for(int de=-90; de<=90; ++de) {
+            double de_rad = de * M_PI/180.0 ;
+            double az_rad = az * M_PI/180.0 ;
+            array.beam_level( de_rad, az_rad, pitch, yaw, freq, &level ) ;
+            of << level(0) ;
+            if( de!=90 ) of << "," ;
+            total += level(0)*cos(de_rad)*(M_PI/180.0)*(M_PI/180.0) ;
+        }
+        of << endl ;
+    }
+
+    // check that the main lobe is at the correct position
+    array.beam_level( pitch+steering, yaw, pitch, yaw, freq, &level ) ;
+    BOOST_CHECK_CLOSE( level(0), 1.0, 1e-3 ) ;
+
+    std::ofstream ef( envname ) ;
+    cout << "Saving environmental and array parameters to " << envname << endl ;
+    ef << "c0,d,n,roll,pitch,yaw,steering,freq" << endl ;
+    ef << c0 << ","
+       << d << ","
+       << n << ","
+       << pitch << ","
+       << yaw << ","
+       << steering << "," ;
+    for(int i=0; i<freq.size(); ++i) {
+        ef << freq(i) ;
+        if( i != freq.size()-1 ) ef << "," ;
+    }
+    ef << endl ;
+
+    total = 10.0*log10( (4*M_PI)/total ) ;
+    array.directivity_index( freq, &level ) ;
+    cout << "Directivity index" << endl ;
+    cout << "analytic: " << level(0) << "\napproximation: " << total << endl ;
+    BOOST_CHECK_CLOSE( level(0), total, 1.0 ) ;
+}
+
+/**
+ * Test the basic features of the beam_pattern_model using
+ * a beam pattern function of solid angle.
+ *
+ * The test fails if either the following are false:
+ *
+ *  - The main lobe is in the correct is not in the correct
+ *    direction. If the maximum response is not in the
+ *    correct direction, the beam level will differ from
+ *    1.0 by greater than 1e-4%
+ *  - The Directivity index is also differs from a
+ *    a Simpson's rule integration approximation of
+ *    directivity index from beam level, by more than
+ *    1.0%.
+ */
+BOOST_AUTO_TEST_CASE( solid_pattern_test ) {
+    cout << "===== beam_pattern_test/solid_pattern_test =====" << endl ;
+    const char* csvname = USML_TEST_DIR "/sensors/test/beam_pattern_solid.csv" ;
+
+    // Physical and Environmental parameters concerning the array
+    double max_de = 20.0 ;
+    double min_de = -20.0 ;
+    double max_az = 135.0 ;
+    double min_az = 45.0 ;
+    vector<double> freq( 1, 900.0 ) ;
+    beam_pattern_solid solid( max_de, min_de, max_az, min_az ) ;
+
+    double pitch = 17.0 ;
+    double yaw = 41.0 ;
+    double d2r = M_PI / 180.0 ;
+
+    std::ofstream of( csvname ) ;
+    cout << "Saving beam data to " << csvname << endl ;
+    vector<double> level( freq.size(), 0.0 ) ;
+    double total = 0 ;
+    for(int az=0; az<=360; ++az) {
+        for(int de=-90; de<=90; ++de) {
+            double de_rad = de * M_PI/180.0 ;
+            double az_rad = az * M_PI/180.0 ;
+            solid.beam_level( de_rad, az_rad, pitch*d2r, yaw*d2r, freq, &level ) ;
+            of << level(0) ;
+            if( de!=90 ) of << "," ;
+            total += level(0)*cos(de_rad)*(M_PI/180.0)*(M_PI/180.0) ;
+            double result = 0.0 ;
+            if( (de<(max_de-pitch)) && (de>=(min_de-pitch)) ) {
+                if( (az<=(max_az+yaw)) && (az>=(min_az+yaw)) ) {
+                    result = 1.0 ;
+                }
+            }
+            BOOST_CHECK_EQUAL( level(0), result ) ;
+        }
+        of << endl ;
+    }
+
+    total = 10.0*log10( (4*M_PI)/total ) ;
+    solid.directivity_index( freq, &level ) ;
+    cout << "Directivity index" << endl ;
+    cout << "analytic: " << level(0) << "\napproximation: " << total << endl ;
+    BOOST_CHECK_CLOSE( level(0), total, 1.5 ) ;
+}
+
+/**
+ * Test for a mesh beam pattern for a 1-D beam pattern. With
+ * 1-D beam patterns the beam_level and directivity_index are
+ * the same values. This test fails if any values that are
+ * passed back are different from the data points for either
+ * directivity_index or beam_level.
+ */
+BOOST_AUTO_TEST_CASE( grid_pattern_1d_test ) {
+    cout << "===== beam_pattern_test/grid_pattern_1d_test =====" << endl ;
+
+    typedef beam_pattern_grid<double,1>     grid_type ;
+
+    const double tmp_data[] = { 1.0, 0.75, 0.5, 0.5, 0.75, 1.0 } ;
+    int N = sizeof(tmp_data)/sizeof(double) ;
+    vector<double> freq(N) ;
+    double axis_data[] = { 10.1, 57.0, 79.0, 81.5, 100.7, 152.7 } ;
+//    seq_vector* axes = new seq_log( 10.0, 10.0, N ) ;
+    seq_vector* axes[1] ;
+    axes[0] = new seq_data( axis_data, N ) ;
+    double* data = new double[N] ;
+    for(int i=0; i<N; ++i) {
+        freq[i] = (*axes[0])[i] ;
+        data[i] = tmp_data[i] ;
+    }
+
+    grid_type test_grid( axes, data, grid_type::LINEAR_UNITS ) ;
+    cout << "frequencies: " << freq << endl ;
+
+    const char* grid_file = "beam_pattern_grid1_test.nc" ;
+    cout << "Writing data_grid to disk, " << grid_file << endl ;
+    test_grid.write_netcdf( grid_file ) ;
+
+    vector<double> level( N, 0.0 ) ;
+    test_grid.beam_level( 0.0, 0.0, 0.0, 0.0, freq, &level ) ;
+    for(int i=0; i<level.size(); ++i) {
+        BOOST_CHECK_CLOSE( tmp_data[i], level(i), 1e-8 ) ;
+    }
+    cout << "beam level: " << level << endl ;
+    test_grid.directivity_index( freq, &level ) ;
+    for(int i=0; i<level.size(); ++i) {
+        double result = 10.0*log10( tmp_data[i] ) ;
+        BOOST_CHECK_EQUAL( result, level(i) ) ;
+    }
+    cout << "Directivity index: " << level << endl ;
+
+    delete axes[0] ;
+    delete data ;
+}
+
+/**
+ * Test for a mesh beam pattern for a 2-D beam pattern.
+ * This test fails if any values that are passed back are
+ * different from the data points for either directivity
+ * index or beam level.
+ */
+BOOST_AUTO_TEST_CASE( grid_pattern_2d_test ) {
+    cout << "===== beam_pattern_test/grid_pattern_2d_test =====" << endl ;
+
+    typedef beam_pattern_grid<double,2>     grid_type ;
+
+    // ----> axis0
+    // |
+    // |
+    // v axis1
+    const double tmp_data[] = { 1.0, 0.75, 0.5, 0.75, 0.81,
+                                0.87, 0.75, 0.5, 0.75, 0.41,
+                                0.2, 0.75, 0.5, 0.75, 0.33,
+                                0.61, 0.75, 0.5, 0.75, 0.97,
+                                0.53, 0.75, 0.5, 0.75, 0.53 } ;
+    int N = sizeof(tmp_data)/sizeof(double) ;
+    int n = sqrt(N) ;
+    seq_linear* frequencies = new seq_linear( 100.0, 100.0, n ) ;
+    vector<double> freq = *frequencies ;
+    seq_vector* de = new seq_linear( to_radians(-2.0), to_radians(1.0), n ) ;
+    seq_vector* axes[2] ;
+    axes[0] = frequencies ;
+    axes[1] = de ;
+    double* data = new double[N] ;
+    for(int i=0; i<N; ++i) {
+        data[i] = tmp_data[i] ;
+    }
+
+    grid_type test_grid( axes, data, grid_type::LINEAR_UNITS ) ;
+    cout << "frequencies: " << freq << endl ;
+
+    const char* grid_file = "beam_pattern_grid2_test.nc" ;
+    cout << "Writing data_grid to disk, " << grid_file << endl ;
+    test_grid.write_netcdf( grid_file ) ;
+
+    vector<double> level( freq.size(), 0.0 ) ;
+    for(int i=0; i<de->size(); ++i) {
+        test_grid.beam_level( (*de)[i], 0.0, 0.0, 0.0, freq, &level ) ;
+        for(int j=0; j<level.size(); ++j) {
+            BOOST_CHECK_CLOSE( tmp_data[j*n+i], level(j), 1e-8 ) ;
+        }
+    }
+    cout << "beam level: " << level << endl ;
+    test_grid.directivity_index( freq, &level ) ;
+    vector<double> sum( n, 0.0 ) ;
+    for(int i=0; i<n; ++i) {
+        for(int j=0; j<n; ++j) {
+            sum[i] += tmp_data[i*n+j] * cos( (*de)[j] ) * de->increment(j) ;
+        }
+    }
+    for(int i=0; i<level.size(); ++i) {
+        double result = 10.0*log10( 2.0 / sum[i] ) ;
+        BOOST_CHECK_EQUAL( result, level(i) ) ;
+    }
+    cout << "Directivity index: " << level << endl ;
+
+    delete frequencies ;
+    delete de ;
+    delete data ;
+}
+
+/**
+ * Test for a mesh beam pattern for a 3-D beam pattern.
+ * This test fails if any values that are passed back are
+ * different from the data points for either directivity
+ * index or beam level.
+ */
+BOOST_AUTO_TEST_CASE( grid_pattern_3d_test ) {
+    cout << "===== beam_pattern_test/grid_pattern_3d_test =====" << endl ;
+
+    typedef beam_pattern_grid<double,3>     grid_type ;
+    typedef grid_type::size_type            size_type ;
+
+    // ----> axis0
+    // |
+    // |
+    // v axis1
+    // * axis2
+
+    int n = 5 ;
+    int N = n*n*n ;
+    seq_linear frequencies( 100.0, 100.0, n ) ;
+    vector<double> freq = frequencies ;
+    seq_linear de( to_radians(-2.0), to_radians(1.0), n ) ;
+    seq_linear az( to_radians(0.0), to_radians(5.0), n ) ;
+    seq_vector* axes[3] ;
+    axes[0] = &frequencies ;
+    axes[1] = &de ;
+    axes[2] = &az ;
+    double* data = new double[N] ;
+    std::srand(1) ;
+    for(int i=0; i<N; ++i) {
+        double v = std::rand() ;
+        data[i] = v/RAND_MAX ;
+    }
+
+    grid_type test_grid( axes, data, grid_type::LINEAR_UNITS ) ;
+    cout << "frequencies: " << freq << endl ;
+
+    const char* grid_file = "beam_pattern_grid3_test.nc" ;
+    cout << "Writing data_grid to disk, " << grid_file << endl ;
+    test_grid.write_netcdf( grid_file ) ;
+
+    size_type num_freq( freq.size() ) ;
+    size_type num_de( de.size() ) ;
+    size_type num_az( az.size() ) ;
+    vector<double> level( num_freq, 0.0 ) ;
+    for(size_type i=0; i<num_de; ++i) {
+        for(size_type j=0; j<num_az; ++j) {
+            test_grid.beam_level( de[i], az[j], 0.0, 0.0, freq, &level ) ;
+            for(int k=0; k<num_freq; ++k) {
+                size_type index = j + num_az*(i + num_de*k) ;
+                BOOST_CHECK_CLOSE( data[index], level(k), 1e-8 ) ;
+            }
+        }
+    }
+    cout << "beam level: " << level << endl ;
+    test_grid.directivity_index( freq, &level ) ;
+    vector<double> sum( num_freq, 0.0 ) ;
+    for(size_type i=0; i<num_de; ++i) {
+        for(size_type j=0; j<num_az; ++j) {
+            for(size_type k=0; k<num_freq; ++k) {
+                size_type index = j + num_az*(i + num_de*k) ;
+                sum[k] += data[index] * cos( de[i] )
+                        * de.increment(i) * az.increment(j) ;
+            }
+        }
+    }
+    for(int i=0; i<num_freq; ++i) {
+        double result = 10.0*log10( (4.0*M_PI) / sum[i] ) ;
+        BOOST_CHECK_CLOSE( result, level(i), 1e-8 ) ;
+    }
+    cout << "Directivity index: " << level << endl ;
+
+    delete data ;
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/sensors/test/horizontal_line_array.m
+++ b/sensors/test/horizontal_line_array.m
@@ -1,0 +1,39 @@
+%% Horizontal line array's beam pattern as via C++ implementation
+
+close all ; clear all ;
+
+[param, desc] = xlsread('horizontal_array_parameters.csv') ;
+c0 = param(1) ;
+d = param(2) ;
+N = param(3) ;
+pitch = param(4) + pi/2 ;
+yaw = param(5) ;
+steering = param(6) ;
+freq = param(7:end) ;
+line_pattern( c0, d, N, pitch, yaw, steering, freq ) ;
+
+data = xlsread('horizontal_array_beam_pattern.csv') ;
+
+db = 10.0 * log10( abs(data) ) ;
+db = db + 30 ;
+m = find( db < 0 ) ;
+db(m) = 0 ;
+
+theta = (0:180)*pi/180 ;    % D/E angles where to evaluate
+phi = (-180:180)*pi/180 ;   % AZ angles where to evaluate
+[theta_grid,phi_grid] = meshgrid(theta,phi) ;
+
+xx = db .* cos(phi_grid) .* sin(theta_grid) ;
+yy = db .* sin(phi_grid) .* sin(theta_grid) ;
+zz = db .* cos(theta_grid) ;
+figure ;
+surf( xx, yy, zz, db, 'EdgeColor','none','FaceColor','interp') ;
+colormap(jet) ;
+view([0 0]) ;
+set(gca,'Xlim',[-30 30]) ;
+set(gca,'Ylim',[-30 30]) ;
+set(gca,'Zlim',[-30 30]) ;
+xlabel('x') ;
+ylabel('y') ;
+zlabel('z') ;
+title('C++ Implementation') ;

--- a/sensors/test/line_pattern.m
+++ b/sensors/test/line_pattern.m
@@ -1,0 +1,65 @@
+%%
+% line_array.m
+%     sound_speed   : speed of sound in water at array
+%     N             : number of elements
+%     spacing       : spacing between elements
+%     roll          : amount of roll on the array
+%     pitch         : amount of pitch in the theta direction (up positive)
+%     yaw           : amount of yaw in the phi direction (clockwise
+%                     positive)
+%     steering      : steering relative to straight up
+%     freq          : signal frequency
+% Produces 3-D plot as function of solid angle.
+%
+function line_pattern( sound_speed, spacing, N, pitch, yaw, steering, freq )
+
+    theta_tilt = pitch ;  % pitch relative to straight up
+    phi_tilt = yaw ;
+%     theta = (0:180)*pi/180 ;    % D/E angles where to evaluate
+%     phi = (-180:180)*pi/180 ;   % AZ angles where to evaluate
+%     [theta_grid,phi_grid] = meshgrid(theta,phi) ;
+    wavelength = sound_speed/freq ; % signal wavelength
+
+    % compute spherical dot product between 
+    % incoming wave directions and the tilted array
+
+    de = (-90:90)*pi/180 ;
+    az = (0:360)*pi/180 ;
+    [de_grid, az_grid] = meshgrid(de,az) ;
+
+    theta_grid = de_grid + pi/2 ;
+    phi_grid = -az_grid ;
+    sint = sin( (theta_grid - theta_tilt) / 2 ) ;
+    sinp = sin( (phi_grid + phi_tilt) / 2 ) ;
+    dotnorm = 1 - 2 * ( sint.*sint ...
+        + sin(theta_grid) .* sin(theta_tilt) .* sinp .* sinp ) ;
+
+    % compute beam pattern with steering along array direction
+
+    C = 2 * pi * spacing / wavelength ;
+    psi = C * dotnorm ;
+    psi_steer = C * sin(steering) ;
+
+    pattern = sin( N*(psi-psi_steer+eps)/2 ) ...
+           ./ (N*sin((psi-psi_steer+eps)/2)) ;
+
+    % cpnvert beam pattern into a 3-d surface plot
+
+    dB = 20*log10( abs(pattern) ) ;
+    dB = dB+30 ; n = find( dB < 0 ) ; dB(n) = 0 ;
+    X = dB .* cos(phi_grid) .* sin(theta_grid) ;
+    Y = dB .* sin(phi_grid) .* sin(theta_grid) ;
+    Z = dB .* cos(theta_grid) ;
+    figure ;
+    h = surf(X,Y,Z,dB,'EdgeColor','none','FaceColor','interp') ;
+    colormap(jet)
+    view([0 0])
+    set(gca,'Xlim',[-30 30])
+    set(gca,'Ylim',[-30 30])
+    set(gca,'Zlim',[-30 30])
+    xlabel('x');
+    ylabel('y');
+    zlabel('z');
+    title('Matlab Implementation') ;
+
+end

--- a/sensors/test/vertical_line_array.m
+++ b/sensors/test/vertical_line_array.m
@@ -1,0 +1,39 @@
+%% Vertical line array's beam pattern as via C++ implementation
+
+close all ; clear all ;
+
+[param, desc] = xlsread('vertical_array_parameters.csv') ;
+c0 = param(1) ;
+d = param(2) ;
+N = param(3) ;
+pitch = param(4) ;
+yaw = param(5) ;
+steering = param(6) ;
+freq = param(7:end) ;
+line_pattern( c0, d, N, pitch, yaw, steering, freq ) ;
+
+data = xlsread('vertical_array_beam_pattern.csv') ;
+
+db = 10.0 * log10( abs(data) ) ;
+db = db + 30 ;
+m = find( db < 0 ) ;
+db(m) = 0 ;
+
+theta = (0:180)*pi/180 ;    % D/E angles where to evaluate
+phi = (-180:180)*pi/180 ;   % AZ angles where to evaluate
+[theta_grid,phi_grid] = meshgrid(theta,phi) ;
+
+xx = db .* cos(phi_grid) .* sin(theta_grid) ;
+yy = db .* sin(phi_grid) .* sin(theta_grid) ;
+zz = db .* cos(theta_grid) ;
+figure ;
+surf( xx, yy, zz, db, 'EdgeColor','none','FaceColor','interp') ;
+colormap(jet) ;
+view([0 0]) ;
+set(gca,'Xlim',[-30 30]) ;
+set(gca,'Ylim',[-30 30]) ;
+set(gca,'Zlim',[-30 30]) ;
+xlabel('x') ;
+ylabel('y') ;
+zlabel('z') ;
+title('C++ Implementation') ;

--- a/studies/malta_movie/malta_movie.cc
+++ b/studies/malta_movie/malta_movie.cc
@@ -42,7 +42,7 @@ int main( int argc, char* argv[] ) {
     wposition::compute_earth_radius( (lat1+lat2)/2.0 ) ;
 
     wposition1 pos( 35.983333333, 16.0, -10.0 ) ;
-    seq_rayfan de( 0.0, 45.0, 181 ) ;
+    seq_rayfan de( -45.0, 0.0, 181 ) ;
     seq_linear az( 225.0, 5.0, 315.0 ) ;
     const double time_max = 60.0 ;
     const double time_step = 0.050 ;

--- a/studies/ray_speed/ray_speed.cc
+++ b/studies/ray_speed/ray_speed.cc
@@ -119,7 +119,10 @@ int main( int argc, char* argv[] ) {
         boost::progress_timer timer ;
         while ( wave.time() < time_max ) {
             wave.step() ;
-        }
+		#ifdef USML_DEBUG
+			wave.save_netcdf();
+		#endif
+		}
     }
 
     #ifdef USML_DEBUG

--- a/types/data_grid.h
+++ b/types/data_grid.h
@@ -173,6 +173,13 @@ class USML_DLLEXPORT data_grid {
         }
 
         /**
+         * Extracts a const pointer to the data member.
+         */
+        inline DATA_TYPE* data() const {
+            return _data ;
+        }
+
+        /**
          * Extract a data value at a specific combination of indices.
          *
          * @param  index            Index number in each dimension.
@@ -223,13 +230,13 @@ class USML_DLLEXPORT data_grid {
             }
 
             NcVar* earth_radius = _file->add_var( "earth_radius", ncDouble, 0 ) ;
-            for(long i=0; i < NUM_DIMS; ++i) {
+            for(size_t i=0; i < NUM_DIMS; ++i) {
                 std::stringstream ss ;
                 ss << "axis" << i << "\0" ;
-                axis_dim[i] = _file->add_dim( (ss.str()).c_str(), _axis[i]->size() ) ;
+                axis_dim[i] = _file->add_dim( (ss.str()).c_str(), (long)_axis[i]->size() ) ;
                 axis_size[i] = axis_dim[i] ;
                 axis_var[i] = _file->add_var( (ss.str()).c_str(), type, axis_dim[i] ) ;
-                data_size[i] = _axis[i]->size() ;
+                data_size[i] = (long)_axis[i]->size() ;
             }
             NcVar* data_var = _file->add_var( "data", type, NUM_DIMS, &*axis_size ) ;
 


### PR DESCRIPTION
Introduction to sensors package with new abstract interface class beam_pattern_model. This class allows the user to construct and request details that are specific to a sensors beam pattern function. With the abstract interface, the user will be able to request beam level (linear units) and directivity index (dB) for a list of frequencies and spatial orientation of the array. The following classes have been created:

beam_pattern_line : pattern of an array of linearly spaced elements
beam_pattern_omni : an omni-directional receive pattern
beam_pattern_cosine : beam pattern for a spacing of two elements equal to lambda/2 with the reference axis in the Northern direction
beam_pattern_sine : beam pattern for a spacing of two elements equal to lambda/2 with the reference axis in the Eastern direction
beam_pattern_solid : beam pattern with maximum response that covers a solid angle
beam_pattern_grid : generalized class for beam patterns that are a function of de/az/frequency

All computations are done in theta/phi and therefore all de/az, pitch/yaw, that are passed to the beam pattern are transformed into these coordinates. Tests for every class, including 3 for beam_pattern_grid, have been included in the test folder along with supporting matlab code.