### PR TITLE
Compute eigenverb widths as a function of freqency

### DIFF
--- a/eigenverb/eigenverb_collection.cc
+++ b/eigenverb/eigenverb_collection.cc
@@ -35,13 +35,13 @@ void eigenverb_collection::write_netcdf(
 		break;
 	default:
 		{
-			int layer = interface - eigenverb::VOLUME_UPPER ;
-			int side = layer % 2 ;
+			size_t layer = interface - eigenverb::VOLUME_UPPER ;
+			size_t side = layer % 2 ;
 			layer = ( layer / 2 ) + 1 ;
 			std::ostringstream oss;
 			oss << ((side)?"lower":"upper") << " volume "  << layer << " eigenverbs" ;
 			nc_file->add_att("long_name", oss.str().c_str());
-			nc_file->add_att("layer", layer);
+			nc_file->add_att("layer", (long)layer);
 		}
 		break;
 	}
@@ -132,14 +132,9 @@ void eigenverb_collection::write_netcdf(
 
 			// translate units
 
-			double* energy = new double[verb.frequencies->size()] ;
-			double* length = new double[verb.frequencies->size()] ;
-			double* width = new double[verb.frequencies->size()] ;
-			for ( int f=0; f < verb.frequencies->size(); ++f ) {
-				energy[f] = 10.0*log10(max(1e-30,verb.energy(f))) ;
-				length[f] = sqrt(verb.length2(f)) ;
-				width[f] = sqrt(verb.width2(f)) ;
-			}
+			vector<double> energy = 10.0*log10(max(verb.energy, 1e-30));
+			vector<double> length = sqrt(verb.length2);
+			vector<double> width = sqrt(verb.width2);
 
 			// inserts data
 
@@ -147,10 +142,9 @@ void eigenverb_collection::write_netcdf(
 			long i ;
 			time_var->put(&verb.time, 1);
 
-			energy_var->put(energy, 1, (long) verb.frequencies->size());
-			length_var->put(length, 1, (long) verb.frequencies->size());
-			width_var->put(width, 1, (long) verb.frequencies->size());
-			delete[] energy, length, width ;
+			energy_var->put(energy.data().begin(), 1, (long) verb.frequencies->size());
+			length_var->put(length.data().begin(), 1, (long) verb.frequencies->size());
+			width_var->put(width.data().begin(), 1, (long) verb.frequencies->size());
 			v = verb.position.latitude(); lat_var->put(&v, 1);
 			v = verb.position.longitude(); lng_var->put(&v, 1);
 			v = verb.position.altitude(); alt_var->put(&v, 1);

--- a/eigenverb/eigenverb_collection.h
+++ b/eigenverb/eigenverb_collection.h
@@ -1,128 +1,188 @@
 /*
  * @file eigenverb_collection.h
+ * Collection of eigenverbs in the form of a vector of eigenverbs_lists.
  */
 #pragma once
 
 #include <usml/eigenverb/eigenverb.h>
 //#include <usml/types/quadtree.h>
 
-using namespace usml::types ;
+using namespace usml::types;
 
 namespace usml {
 namespace eigenverb {
 
 //typedef quadtree_type<eigenverb,100>::points   eigenverb_tree ;
+
 /**
+ * Collection of eigenverbs in the form of a vector of eigenverbs_lists.
+ * Each index represents a different interface.
  *
+ *    - index=0 is eigenverbs for the bottom.
+ *    - index=1 is eigenverbs for the surface.
+ *    - index=2 is for the upper interface of the first
+ *    	volume scattering layer, if it exists.
+ *    - index=3 is for the lower interface of the first
+ *    	volume scattering layer, if it exists.
+ *    - Subsequent columns provide the upper and lower
+ *    	interfaces for additional volume scattering layers.
  */
 class USML_DECLSPEC eigenverb_collection {
 
-    public:
+public:
 
-	// Shared pointer
-	typedef boost::shared_ptr <eigenverb_collection> reference;
+	/**
+	 * Shared pointer reference to an eigenverb _collection.
+	 */
+	typedef boost::shared_ptr<eigenverb_collection> reference;
 
-        /**
-         * Constructor
-         *
-         * @param lon
-         * @param lat
-         * @param lon_range
-         * @param lat_range
-         * @param layers
-         */
-        eigenverb_collection( size_t layers = 0 ) ;
-//        eigenverb_collection(
-//                double lon,
-//                double lat,
-//                double lon_range, double lat_range,
-//                size_t layers = 0 ) ;
+	/**
+	 * Construct a collection for a specific scenario.  Creates a minimum
+	 * of interfaces (index 0=bottom, 1=surface), plus two for each
+	 * volume scattering layer.
+	 *
+	 * @param num_volume	Number of volume scattering layers in the ocean.
+	 */
+	eigenverb_collection(size_t num_volumes) :
+			_collection((1 + num_volumes) * 2) {
+	}
 
-        /*
-         * Destructor
-         */
-        virtual ~eigenverb_collection() ;
+	/*
+	 * Virtual destructor
+	 */
+	virtual ~eigenverb_collection() {
+	}
 
-        /**
-         *
-         *
-         * @param e
-         * @param i
-         */
-        virtual void add_eigenverb(
-            eigenverb e, interface_type i ) ;
+	/**
+	 * Number of interfaces in this collection.
+	 */
+	size_t num_interfaces() const {
+		return _collection.size();
+	}
 
-        /**
-         * Returns the list of eigenverbs for the bottom
-         * interface
-         */
-        eigenverb_list bottom() const ;
+	/**
+	 * Provides access to eigenverbs for a specific combination
+	 * of azimuth and interface.
+	 *
+	 * @param interface	Interface number of the desired list of eigenverbs.
+	 * 					See the class header for documentation on interpreting
+	 * 					this number.  For some layers, you can also use the
+	 * 					eigenverb::interface_type.
+	 */
+	const eigenverb_list& eigenverbs(size_t interface) const {
+		return _collection[interface];
+	}
 
-        /**
-         * Returns the list of eigenverbs for the surface
-         * interface
-         */
-        eigenverb_list surface() const ;
+	/**
+	 * Adds a new eigenverb to this collection.  Make a copy of the new
+	 * contribution and stores the copy in its collection.
+	 *
+	 * @param interface	Interface number of the desired list of eigenverbs.
+	 * 					See the class header for documentation on interpreting
+	 * 					this number. For some layers, you can also use the
+	 * 					eigenverb::interface_type.
+	 */
+	void add_eigenverb(const eigenverb& verb, size_t interface) {
+		_collection[interface].push_back(verb);
+	}
 
-        /**
-         * Returns the list of eigenverbs for the volume
-         * upper interface
-         */
-        vector<eigenverb_list> upper() const ;
+	/**
+	 * Writes the eigenverbs for an individual interface to a netcdf file.
+	 * There are separate variables for each eigenverb component,
+	 * and each eigenverb add a row to that variable.  The energy,
+	 * length, and width variables have a column for each frequency.
+	 *
+	 * An example of the file format is given below.
+	 * <pre>
+     * netcdf eigenverb_basic_2 {
+     * dimensions:
+     *         eigenverbs = 24 ;
+     *         frequency = 2 ;
+     * variables:
+     *         double travel_time(eigenverbs) ;
+     *                 travel_time:units = "seconds" ;
+     *         double frequency(frequency) ;
+     *                 frequency:units = "hertz" ;
+     *         double energy(eigenverbs, frequency) ;
+     *                 energy:units = "linear" ;
+     *         double length(eigenverbs, frequency) ;
+     *                 length:units = "meters" ;
+     *         double width(eigenverbs, frequency) ;
+     *                 width:units = "meters" ;
+     *         double latitude(eigenverbs) ;
+     *                 latitude:units = "degrees_north" ;
+     *         double longitude(eigenverbs) ;
+     *                 longitude:units = "degrees_east" ;
+     *         double altitude(eigenverbs) ;
+     *                 altitude:units = "meters" ;
+     *         double direction(eigenverbs) ;
+     *                 direction:units = "degrees_true" ;
+     *                 direction:positive = "clockwise" ;
+     *         double grazing_angle(eigenverbs) ;
+     *                 grazing_angle:units = "degrees" ;
+     *                 grazing_angle:positive = "up" ;
+     *         short de_index(eigenverbs) ;
+     *                 de_index:units = "count" ;
+     *         short az_index(eigenverbs) ;
+     *                 az_index:units = "count" ;
+     *         double launch_de(eigenverbs) ;
+     *                 launch_de:units = "degrees" ;
+     *                 launch_de:positive = "up" ;
+     *         double launch_az(eigenverbs) ;
+     *                 launch_az:units = "degrees_true" ;
+     *                 launch_az:positive = "clockwise" ;
+     *         short surface(eigenverbs) ;
+     *                 surface:units = "count" ;
+     *         short bottom(eigenverbs) ;
+     *                 bottom:units = "count" ;
+     *         short caustic(eigenverbs) ;
+     *                 caustic:units = "count" ;
+     *         short upper(eigenverbs) ;
+     *                 upper:units = "count" ;
+     *         short lower(eigenverbs) ;
+     *                 lower:units = "count" ;
+     *
+     * // global attributes:
+     *                 :long_name = "upper volume eigenverbs" ;
+     *                 :layer = 1 ;
+     * data:
+     *  travel_time = 2.84871692946947, 2.84871692946947, 2.84871692946947,
+     *     2.84871692946947, 2.84871692946947, 2.84871692946947, 2.84871692946947,
+     *     2.84871692946947, 3.04632321841142, 3.04632321841142, 3.04632321841142,
+     *     3.04632321841142, 3.04632321841142, 3.04632321841142, 3.04632321841142,
+     *     3.04632321841142, 3.30040431394488, 3.30040431394488, 3.30040431394488,
+     *     3.30040431394488, 3.30040431394488, 3.30040431394488, 3.30040431394488,
+     *     3.30040431394488 ;
+     *
+     *  frequency = 2000, 4000 ;
+     *
+     *  energy =
+     *   7.37605571805747e-05, 7.37605571805747e-05,
+     *   7.37605571805747e-05, 7.37605571805747e-05,
+     *   etc...
+     *
+     * }
+	 * <pre>
+	 * If the interface has no eigenverbs, the file will contain only the
+	 * global attributes, and there will be no dimensions, variables,
+	 * or data.
+	 *
+	 * @param filename  File uses to store this data.
+	 * @param interface	Interface number of the desired list of eigenverbs.
+	 * 					See the class header for documentation interpreting
+	 * 					this number.
+	 */
+	void write_netcdf(const char* filename, size_t interface) const;
 
-        /**
-         * Returns the list of eigenverbs for the l'th volume
-         * upper interface
-         */
-        eigenverb_list upper( size_t l ) const ;
+private:
 
-        /**
-         * Returns the list of eigenverbs for the volume
-         * lower interface
-         */
-        vector<eigenverb_list> lower() const ;
-
-        /**
-         * Returns the list of eigenverbs for the l'th volume
-         * lower interface
-         */
-        eigenverb_list lower( size_t l ) const ;
-
-        /**
-         * Returns true if there are volume layers, ie the size
-         * of either _upper or _lower are not zero.
-         */
-        bool volume() const ;
-
-        /**
-         * Saves the eigenverbs from an interface to a netcdf file
-         *
-         * @param filename
-         * @param i
-         */
-        void write_netcdf( const char* filename, interface_type i ) ;
-
-    protected:
-
-        /**
-         * List of all the eigenverbs for bottom boundary collisions
-         */
-        eigenverb_list _bottom ;
-
-        /**
-         * List of all the eigenverbs for surface boundary collisions
-         */
-        eigenverb_list _surface ;
-
-        /**
-         * Vector of eigenverb lists for upper volume layer collisions
-         */
-        vector<eigenverb_list> _upper ;
-
-        /**
-         * Vector of eigenverb lists for lower volume layer collisions
-         */
-        vector<eigenverb_list> _lower ;
+	/**
+	 * Collection of eigenverbs.
+	 *
+	 * TODO Use an quadtree instead of a std::list to store the eigenverbs,
+	 *      We hope this will improve the speed of envelope calculations.
+	 */
+	std::vector<eigenverb_list> _collection;
 };
 
 }   // end of namespace waveq3d

--- a/eigenverb/envelope_bistatic.cc
+++ b/eigenverb/envelope_bistatic.cc
@@ -36,14 +36,15 @@ void envelope_bistatic::compute_bottom_energy(
     const eigenverb_collection& receiver,
     envelope_collection* levels )
 {
-    #ifdef EIGENVERB_MODEL_DEBUG
-        cout << "**** Entering eigenverb_bistatic::compute_bottom_energy()"
-             << endl ;
-//        cout << "Number of source bottom verbs: " << source.bottom().size() << endl ;
-//        cout << "Number of receiver bottom verbs: " << receiver.bottom().size() << endl ;
-    #endif
-    _current_boundary = _bottom_boundary ;
-    convolve_eigenverbs( source.bottom(), receiver.bottom(), levels ) ;
+	//	TODO stub out while we update eigenverb_collection
+//    #ifdef EIGENVERB_MODEL_DEBUG
+//        cout << "**** Entering eigenverb_bistatic::compute_bottom_energy()"
+//             << endl ;
+////        cout << "Number of source bottom verbs: " << source.bottom().size() << endl ;
+////        cout << "Number of receiver bottom verbs: " << receiver.bottom().size() << endl ;
+//    #endif
+//    _current_boundary = _bottom_boundary ;
+//    convolve_eigenverbs( source.bottom(), receiver.bottom(), levels ) ;
 }
 
 /**
@@ -55,14 +56,15 @@ void envelope_bistatic::compute_surface_energy(
     const eigenverb_collection& receiver,
     envelope_collection* levels )
 {
-    #ifdef EIGENVERB_MODEL_DEBUG
-        cout << "**** Entering eigenverb_bistatic::compute_surface_energy()"
-             << endl ;
-//        cout << "Number of source surface verbs: " << source.surface().size() << endl ;
-//        cout << "Number of receiver surface verbs: " << receiver.surface().size() << endl ;
-    #endif
-    _current_boundary = _surface_boundary ;
-    convolve_eigenverbs( source.surface(), receiver.surface(), levels ) ;
+	//	TODO stub out while we update eigenverb_collection
+//    #ifdef EIGENVERB_MODEL_DEBUG
+//        cout << "**** Entering eigenverb_bistatic::compute_surface_energy()"
+//             << endl ;
+////        cout << "Number of source surface verbs: " << source.surface().size() << endl ;
+////        cout << "Number of receiver surface verbs: " << receiver.surface().size() << endl ;
+//    #endif
+//    _current_boundary = _surface_boundary ;
+//    convolve_eigenverbs( source.surface(), receiver.surface(), levels ) ;
 }
 
 /**

--- a/eigenverb/envelope_collection.h
+++ b/eigenverb/envelope_collection.h
@@ -108,10 +108,13 @@ struct USML_DECLSPEC eigenverb_box {
     : x( e.position.longitude() ),
       y( e.position.latitude() )
     {
-        width = std::abs(e.sigma_az * cos( e.launch_az )
-                        - e.sigma_de * sin( e.launch_az ) ) ;
-        height = std::abs(e.sigma_de * cos( e.launch_az )
-                        + e.sigma_az * sin( e.launch_az ) ) ;
+    	width = 1.0 ;
+    	height = 1.0 ;
+//    	TODO stubbed out
+//        width = std::abs(e.width2 * cos( e.launch_az )
+//                        - e.length2 * sin( e.launch_az ) ) ;
+//        height = std::abs(e.length2 * cos( e.launch_az )
+//                        + e.width2 * sin( e.launch_az ) ) ;
     }
 
     /**

--- a/eigenverb/envelope_generator.cc
+++ b/eigenverb/envelope_generator.cc
@@ -12,12 +12,13 @@ void envelope_generator::generate_envelopes(
     const eigenverb_collection& receiver,
     envelope_collection* levels )
 {
-    compute_bottom_energy( source, receiver, levels ) ;
-    compute_surface_energy( source, receiver, levels ) ;
-    if( source.volume() ) {
-        compute_upper_volume_energy( source, receiver, levels ) ;
-        compute_lower_volume_energy( source, receiver, levels ) ;
-    }
+	//	TODO stub out while we update eigenverb_collection
+//    compute_bottom_energy( source, receiver, levels ) ;
+//    compute_surface_energy( source, receiver, levels ) ;
+//    if( source.volume() ) {
+//        compute_upper_volume_energy( source, receiver, levels ) ;
+//        compute_lower_volume_energy( source, receiver, levels ) ;
+//    }
 }
 
 /**
@@ -27,71 +28,72 @@ void envelope_generator::compute_contribution(
     const eigenverb* u, const eigenverb* v,
     envelope_collection* levels )
 {
-        // determine the relative angle and distance between the projected gaussians
-    double alpha, chi, beta, dummy ;
-    u->direction.direction( &dummy, &beta ) ;
-    v->direction.direction( &dummy, &chi ) ;
-    alpha = std::abs(std::fmod(chi,M_PI_2)) + std::abs(std::fmod(beta,M_PI_2)) ;
-    double range = v->position.gc_range( u->position ) ;
-    double xs = range * sin( alpha ) ;
-    double ys = range * cos( alpha ) ;
-    double cos_2alpha = cos( 2.0 * alpha ) ;
-
-        // Compute the intersection of the gaussian profiles
-    double Wr = v->sigma_az ;
-    double Wr2 = Wr*Wr ;
-    double Lr = v->sigma_de ;
-    double Lr2 = Lr*Lr ;
-    double Ws = u->sigma_az ;
-    double Ws2 = Ws*Ws ;
-    double Ls = u->sigma_de ;
-    double Ls2 = Ls*Ls ;
-    double s_minus = Ls2 - Ws2 ;
-    double r_minus = Lr2 - Wr2 ;
-    double s_plus = Ls2 + Ws2 ;
-    double det_sr = 0.5 * ( 2.0*(Ls2*Ws2 + Lr2*Wr2) + s_plus*(Lr2+Wr2) - s_minus*r_minus*cos_2alpha ) ;
-    double kappa = -0.25 * ( xs*xs*(s_plus + s_minus*cos_2alpha + 2.0*Lr2)
-                             + ys*ys*(s_plus - s_minus*cos_2alpha + 2.0*Wr2)
-                             - xs*ys*s_minus*sin(2.0*alpha) ) / det_sr ;
-//    double det_sr = 0.5 * ( 2.0*(Ls2*Ws2 + Lr2*Wr2) + (Ls2+Ws2)*(Lr2+Wr2) - (Ls2-Ws2)*(Lr2-Wr2)*cos(2.0*alpha) ) ;
-//    double kappa = -0.25 * (xs*xs*((Ls2+Ws2)+(Ls2-Ws2)*cos(2.0*alpha)+2.0*Lr2)
-//                          + ys*ys*((Ls2+Ws2)-(Ls2-Ws2)*cos(2.0*alpha)+2.0*Wr2)
-//                          - xs*ys*(Ls2-Ws2)*sin(2.0*alpha)) / det_sr ;
-    double _area = 0.5 * Lr * Ls * Ws * Wr * exp( kappa ) / sqrt(det_sr) ;
-        // Compute the energy reflected off of this patch
-        // and the scattering loss from the interface
-    vector<double> scatter( (*u->frequencies).size() ) ;
-    _current_boundary->scattering( v->position, (*v->frequencies),
-            u->grazing, v->grazing, u->launch_az, v->launch_az, &scatter ) ;
-    double energy = _pulse * u->intensity(0) * v->intensity(0) * scatter(0) * _area ;
-
-    #ifdef DEBUG_CONVOLUTION
-        cout << "*****Eigenverb Convolution*****" << endl ;
-        cout << "    Travel time:     " << u->travel_time + v->travel_time << endl ;
-        cout << "        DE:          " << u->launch_de << endl ;
-        cout << "     Path length:    " << u->distance << endl ;
-        cout << "       range:        " << range << endl ;
-        cout << "        xs:          " << xs << endl ;
-        cout << "        ys:          " << ys << endl ;
-        cout << "       Area:         " << _area << endl ;
-        cout << "   grazing angle:    " << u->grazing*180.0/M_PI << endl ;
-        cout << "      Loss in:       " << 10.0*log10(u->intensity) << endl ;
-        cout << "      Loss out:      " << 10.0*log10(v->intensity) << endl ;
-        cout << "     Two-way TL:     " << 10.0*log10(element_prod(u->intensity, v->intensity)) << endl ;
-        cout << "scattering strength: " << 10.0*log10(scatter) << endl ;
-        cout << "      Energy:        " << 10.0*log10(_energy) << endl ;
-    #endif
-
-        // Only added value if contribution is significant
-    if ( energy > 1e-18 ) {
-            // Calculate the time spread of the energy
-        double sigma_p_yy = ( Lr2 * ( Wr2*Ws2 + Ls2*(Wr2+2.0*Ws2) + Wr2*s_minus*cos_2alpha ) ) /
-            ( Ls2*Wr2 + 2.0*Ls2*Ws2 + Wr2*Ws2 + Lr2*(Ls2+2.0*Wr2+Ws2) - r_minus*s_minus*cos_2alpha ) ;
-//        double sigma_p_yy = ( Lr2 * ( Wr2*Ws2 + Ls2*(Wr2+2.0*Ws2) + Wr2*(Ls2-Ws2)*cos_2alpha ) ) /
-//            ( Ls2*Wr2 + 2.0*Ls2*Ws2 + Wr2*Ws2 + Lr2*(Ls2+2.0*Wr2+Ws2) - (Lr2-Wr2)*(Ls2-Ws2)*cos_2alpha ) ;
-        double Tarea = sqrt(sigma_p_yy) * sin(v->grazing) / v->sound_speed ;
-        double Tsr = 0.5 * sqrt(_pulse*_pulse + Tarea*Tarea) ;
-        double time = u->travel_time + v->travel_time + Tsr ;
-        levels->add_gaussian( energy, time, Tsr, v->az_index ) ;
-    }
+//	TODO stubbed out
+//        // determine the relative angle and distance between the projected gaussians
+//    double alpha, chi, beta, dummy ;
+//    u->direction.direction( &dummy, &beta ) ;
+//    v->direction.direction( &dummy, &chi ) ;
+//    alpha = std::abs(std::fmod(chi,M_PI_2)) + std::abs(std::fmod(beta,M_PI_2)) ;
+//    double range = v->position.gc_range( u->position ) ;
+//    double xs = range * sin( alpha ) ;
+//    double ys = range * cos( alpha ) ;
+//    double cos_2alpha = cos( 2.0 * alpha ) ;
+//
+//        // Compute the intersection of the gaussian profiles
+//    double Wr = v->width2 ;
+//    double Wr2 = Wr*Wr ;
+//    double Lr = v->length2 ;
+//    double Lr2 = Lr*Lr ;
+//    double Ws = u->width2 ;
+//    double Ws2 = Ws*Ws ;
+//    double Ls = u->length2 ;
+//    double Ls2 = Ls*Ls ;
+//    double s_minus = Ls2 - Ws2 ;
+//    double r_minus = Lr2 - Wr2 ;
+//    double s_plus = Ls2 + Ws2 ;
+//    double det_sr = 0.5 * ( 2.0*(Ls2*Ws2 + Lr2*Wr2) + s_plus*(Lr2+Wr2) - s_minus*r_minus*cos_2alpha ) ;
+//    double kappa = -0.25 * ( xs*xs*(s_plus + s_minus*cos_2alpha + 2.0*Lr2)
+//                             + ys*ys*(s_plus - s_minus*cos_2alpha + 2.0*Wr2)
+//                             - xs*ys*s_minus*sin(2.0*alpha) ) / det_sr ;
+////    double det_sr = 0.5 * ( 2.0*(Ls2*Ws2 + Lr2*Wr2) + (Ls2+Ws2)*(Lr2+Wr2) - (Ls2-Ws2)*(Lr2-Wr2)*cos(2.0*alpha) ) ;
+////    double kappa = -0.25 * (xs*xs*((Ls2+Ws2)+(Ls2-Ws2)*cos(2.0*alpha)+2.0*Lr2)
+////                          + ys*ys*((Ls2+Ws2)-(Ls2-Ws2)*cos(2.0*alpha)+2.0*Wr2)
+////                          - xs*ys*(Ls2-Ws2)*sin(2.0*alpha)) / det_sr ;
+//    double _area = 0.5 * Lr * Ls * Ws * Wr * exp( kappa ) / sqrt(det_sr) ;
+//        // Compute the energy reflected off of this patch
+//        // and the scattering loss from the interface
+//    vector<double> scatter( (*u->frequencies).size() ) ;
+//    _current_boundary->scattering( v->position, (*v->frequencies),
+//            u->grazing, v->grazing, u->launch_az, v->launch_az, &scatter ) ;
+//    double energy = _pulse * u->intensity(0) * v->intensity(0) * scatter(0) * _area ;
+//
+//    #ifdef DEBUG_CONVOLUTION
+//        cout << "*****Eigenverb Convolution*****" << endl ;
+//        cout << "    Travel time:     " << u->travel_time + v->travel_time << endl ;
+//        cout << "        DE:          " << u->launch_de << endl ;
+//        cout << "     Path length:    " << u->distance << endl ;
+//        cout << "       range:        " << range << endl ;
+//        cout << "        xs:          " << xs << endl ;
+//        cout << "        ys:          " << ys << endl ;
+//        cout << "       Area:         " << _area << endl ;
+//        cout << "   grazing angle:    " << u->grazing*180.0/M_PI << endl ;
+//        cout << "      Loss in:       " << 10.0*log10(u->intensity) << endl ;
+//        cout << "      Loss out:      " << 10.0*log10(v->intensity) << endl ;
+//        cout << "     Two-way TL:     " << 10.0*log10(element_prod(u->intensity, v->intensity)) << endl ;
+//        cout << "scattering strength: " << 10.0*log10(scatter) << endl ;
+//        cout << "      Energy:        " << 10.0*log10(_energy) << endl ;
+//    #endif
+//
+//        // Only added value if contribution is significant
+//    if ( energy > 1e-18 ) {
+//            // Calculate the time spread of the energy
+//        double sigma_p_yy = ( Lr2 * ( Wr2*Ws2 + Ls2*(Wr2+2.0*Ws2) + Wr2*s_minus*cos_2alpha ) ) /
+//            ( Ls2*Wr2 + 2.0*Ls2*Ws2 + Wr2*Ws2 + Lr2*(Ls2+2.0*Wr2+Ws2) - r_minus*s_minus*cos_2alpha ) ;
+////        double sigma_p_yy = ( Lr2 * ( Wr2*Ws2 + Ls2*(Wr2+2.0*Ws2) + Wr2*(Ls2-Ws2)*cos_2alpha ) ) /
+////            ( Ls2*Wr2 + 2.0*Ls2*Ws2 + Wr2*Ws2 + Lr2*(Ls2+2.0*Wr2+Ws2) - (Lr2-Wr2)*(Ls2-Ws2)*cos_2alpha ) ;
+//        double Tarea = sqrt(sigma_p_yy) * sin(v->grazing) / v->sound_speed ;
+//        double Tsr = 0.5 * sqrt(_pulse*_pulse + Tarea*Tarea) ;
+//        double time = u->travel_time + v->travel_time + Tsr ;
+//        levels->add_gaussian( energy, time, Tsr, v->az_index ) ;
+//    }
 }

--- a/eigenverb/envelope_monostatic.cc
+++ b/eigenverb/envelope_monostatic.cc
@@ -48,13 +48,14 @@ void envelope_monostatic::compute_bottom_energy(
         const eigenverb_collection& receiver,
         envelope_collection* levels )
 {
-    #ifndef EIGENVERB_MODEL_DEBUG
-        cout << "**** Entering eigenverb_monostatic::compute_bottom_energy()"
-             << endl ;
-        cout << "Number of bottom eigenverbs: " << source.bottom().size() << endl ;
-    #endif
-    _current_boundary = _bottom_boundary ;
-    convolve_eigenverbs( source.bottom(), levels ) ;
+//	TODO stub out while we update eigenverb_collection
+//    #ifndef EIGENVERB_MODEL_DEBUG
+//        cout << "**** Entering eigenverb_monostatic::compute_bottom_energy()"
+//             << endl ;
+//        cout << "Number of bottom eigenverbs: " << source.bottom().size() << endl ;
+//    #endif
+//    _current_boundary = _bottom_boundary ;
+//    convolve_eigenverbs( source.bottom(), levels ) ;
 }
 
 /**
@@ -66,13 +67,14 @@ void envelope_monostatic::compute_surface_energy(
     const eigenverb_collection& receiver,
     envelope_collection* levels )
 {
-    #ifndef EIGENVERB_MODEL_DEBUG
-        cout << "**** Entering eigenverb_monostatic::compute_surface_energy()"
-             << endl ;
-        cout << "Number of surface eigenverbs: " << source.surface().size() << endl ;
-    #endif
-    _current_boundary = _surface_boundary ;
-    convolve_eigenverbs( source.surface(), levels ) ;
+	//	TODO stub out while we update eigenverb_collection
+//    #ifndef EIGENVERB_MODEL_DEBUG
+//        cout << "**** Entering eigenverb_monostatic::compute_surface_energy()"
+//             << endl ;
+//        cout << "Number of surface eigenverbs: " << source.surface().size() << endl ;
+//    #endif
+//    _current_boundary = _surface_boundary ;
+//    convolve_eigenverbs( source.surface(), levels ) ;
 }
 
 /**

--- a/eigenverb/test/eigenverb_test.cc
+++ b/eigenverb/test/eigenverb_test.cc
@@ -1,0 +1,186 @@
+/**
+ * @example eigenverb/test/eigenverb_test.cc
+ */
+
+#include <boost/test/unit_test_suite.hpp>
+#include <boost/test/unit_test.hpp>
+#include <boost/foreach.hpp>
+#include <usml/eigenverb/eigenverb_collection.h>
+#include <usml/waveq3d/waveq3d.h>
+
+BOOST_AUTO_TEST_SUITE(eigenverb_test)
+
+using namespace boost::unit_test;
+using namespace usml::waveq3d;
+
+/**
+ * @ingroup waveq3d_test
+ * @{
+ */
+
+static const double time_step = 0.100 ;
+static const double src_lat = 45.0;        // location = mid-Atlantic
+static const double src_lng = -45.0;
+static const double c0 = 1500.0;           // constant sound speed
+
+/**
+ * Tests the basic features of the eigenverb generation process.
+ *
+ * - Scenario parameters
+ *   - Profile: constant 1500 m/s sound speed, Thorp absorption
+ *   - Bottom: 1000 meters, sand
+ *   - Source: 45N, 45W, on surface, 100, 1000, and 10000 Hz
+ *   - Target: 45.02N, 45W, on bottom
+ *   - Time Step: 100 msec
+ *   - Launch D/E: 5 degree linear spacing from -60 to 60 degrees
+ *   - Launch AZ: 10 degree linear spacing from -40 to 40 degrees
+ *
+ * Automatically checks the accuracy of the eigenverbs for the bottom
+ * to the analytic solution in the reverberation paper.
+ *
+ * To maximize accuracy we compute path length and angles on a round earth
+ * with a flat bottom, using eqn. (25) - (27) from the verification test report.
+ * For a path with a given DE (where negative is down), the path length for
+ * the first interaction with the bottom is found by solving eqn. (25) for L:
+ * <pre>
+ *     Rb^2 = R^2 + L^2 - 2 R L sin(DE)
+ *     L^2 - 2 R L sin(DE) + (R^2 - Rb^2) = 0
+ * </pre>
+ * where
+ * 		- R = source distance from earth center,
+ *		- Rb = bottom distance from earth center,
+ *		- DE = launch D/E angle, and
+ *		- L = path length.
+ *
+ * The quadratic equation solution for the path length is
+ * <pre>
+ * 		p = R sin(abs(DE))
+ * 		q = R^2 - Rb^2
+ * 		L = p - sqrt( p*p - q )
+ * </pre>
+ * The negative root has been chosen to make an acute angle between Rs and Rb.
+ * The angle between Rs and Rb is given by:
+ * <pre>
+ * 		L^2 = R^2 + Rb^2 - 2 R Rb cos(alpha) ;
+ * 		alpha = acos[ ( Rs^2 + Rb^2 - L^2 ) / (2 Rs Rb) ]
+ * </pre>
+ * The time of arrival and grazing angle are given by:
+ * <pre>
+ * 		time = L / c ;
+ * 		grazing = DE - alpha
+ * </pre>
+ * @xref Sean Reilly, David Thibaudeau, Ted Burns,
+ * 		 "Fast computation of reverberation using Gaussian beam reflections",
+ * 		 report prepared for NAWCTSD
+ * @xref Sean Reilly, Gopu Potty, "Verification Tests for Hybrid Gaussian
+ *		 Beams in Spherical/Time Coordinates", 10 May 2012.
+ */
+BOOST_AUTO_TEST_CASE( eigenverb_basic ) {
+    cout << "=== eigenverb_test: eigenverb_basic ===" << endl;
+    const char* ncname = USML_TEST_DIR "/eigenverb/test/eigenverb_basic_";
+    const char* ncname_wave = USML_TEST_DIR "/eigenverb/test/eigenverb_basic_wave.nc";
+    const double time_max = 3.5;
+    const double depth = 1000.0 ;
+    const double de_spacing = 5.0 ;
+    const double az_spacing = 10.0 ;
+
+    // initialize propagation model
+
+	profile_model* profile = new profile_linear(c0);
+	boundary_model* surface = new boundary_flat();
+	reflect_loss_model* bottom_loss = new reflect_loss_rayleigh(reflect_loss_rayleigh::SAND) ;
+	boundary_model* bottom = new boundary_flat(depth,bottom_loss);
+	ocean_model ocean(surface, bottom, profile);
+	volume_model* layer = new volume_flat(300.0, 10.0, -40.0);
+	ocean.add_volume(layer);
+
+    seq_log freq( 100.0, 10.0, 10e3 );
+    wposition1 pos( src_lat, src_lng, 0.0 );
+    seq_linear de( -60.0, de_spacing, 60.0 );
+    seq_linear az( -40.0, az_spacing, 40.1 );
+
+    // build a wavefront that just generates eigenverbs
+
+    eigenverb_collection* eigenverbs = new eigenverb_collection( ocean.num_volume() ) ;
+    wave_queue wave( ocean, freq, pos, de, az, time_step ) ;
+    wave.add_eigenverb_listener(eigenverbs) ;
+
+    // propagate rays and record wavefronts to disk.
+
+    cout << "propagate wavefronts for " << time_max << " seconds" << endl;
+    cout << "writing wavefronts to " << ncname_wave << endl;
+
+    wave.init_netcdf( ncname_wave );
+    wave.save_netcdf();
+    while ( wave.time() < time_max ) {
+        wave.step();
+        wave.save_netcdf();
+    }
+    wave.close_netcdf();
+
+    // record eigenverbs for each interface to their own disk file
+
+    for ( int n=0 ; n < eigenverbs->num_interfaces() ; ++n ) {
+    	std::ostringstream filename ;
+    	filename << ncname << n << ".nc" ;
+    	eigenverbs->write_netcdf( filename.str().c_str(),n) ;
+    }
+
+    // compute the sound speed at the bottom for rofile->flat_earth(true) ;
+    const double c_bottom = c0 * (wposition::earth_radius-depth)
+    		/ wposition::earth_radius ;
+
+    // test the accuracy of the eigenverb contributions
+    // just tests downward facing rays to the bottom, along az=0
+
+    const eigenverb_list& list = eigenverbs->eigenverbs(eigenverb::BOTTOM) ;
+    BOOST_FOREACH( eigenverb verb, list ) {
+		if ( verb.source_de < 0.0 && verb.source_az == 0.0
+			&& verb.surface == 0 && verb.bottom == 0 )
+		{
+			int segments = verb.bottom + verb.surface + 1;
+			double R = wposition::earth_radius ;
+			double Rb = wposition::earth_radius - depth ;
+			double p = R * sin(abs(verb.source_de)) ;
+			double q = R * R - Rb * Rb ;
+			double path_length = p - sqrt( p*p - q ) ; // quadratic equation
+
+			double alpha = acos( ( R * R + Rb * Rb - path_length * path_length )
+					/ ( 2 * R * Rb ) ) ;
+			double grazing = abs(verb.source_de) - alpha ;
+			path_length *= segments ;
+			double time = path_length / c0 ;
+
+			double L = 2.0 * path_length * to_radians(de_spacing) ;
+			double W = 2.0 * path_length * to_radians(az_spacing) * cos(verb.source_de);
+			vector<double> spread = abs2( TWO_PI * c0 / (*verb.frequencies) ) ;
+//			vector<double> spread = zero_vector<double>(verb.frequencies->size()) ;
+			vector<double> verb_length = sqrt( spread + L*L ) / sin(grazing) ;
+			vector<double> verb_width = sqrt( spread + W*W ) ;
+
+			// compare to results computed by model
+
+			BOOST_CHECK_SMALL( verb.time-time, 1e-3 ) ;
+			BOOST_CHECK_SMALL( verb.grazing-grazing, 1e-6 ) ;
+			BOOST_CHECK_SMALL( verb.direction-verb.source_az, 1e-6 ) ;
+			for ( int f=0; f < verb.frequencies->size() ; ++f ) {
+				cout << "f=" << (*verb.frequencies)(f)
+							 << "\tL=" << sqrt(verb.length2(f))
+							 << " true=" << verb_length(f)
+							 << "\tW=" << sqrt(verb.width2(f))
+							 << " true=" << verb_width(f)
+					 << endl ;
+				BOOST_CHECK_SMALL( sqrt(verb.length2(f))-verb_length(f), 0.1 ) ;
+				BOOST_CHECK_SMALL( sqrt(verb.width2(f))-verb_width(f), 0.1 ) ;
+			}
+		}
+    }
+
+    // clean up and exit
+
+    delete eigenverbs ;
+}
+
+/// @}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/types/wvector1.cc
+++ b/types/wvector1.cc
@@ -129,7 +129,7 @@ void wvector1::direction(const wvector1& pos, const wvector1& dir)
  * Extract spherical earth geocentric direction from acoustic
  * ray direction in the local tangent plane.
  */
-void wvector1::direction(const wvector1& pos, wvector1* dir)
+void wvector1::direction(const wvector1& pos, wvector1* dir) const
 {
     const double st = sin(pos.theta());
     const double ct = cos(pos.theta());

--- a/types/wvector1.h
+++ b/types/wvector1.h
@@ -210,7 +210,7 @@ public:
      * @param  dir          Direction in terms of a spherical earth vector
      *                      (output).
      */
-    void direction(const wvector1& pos, wvector1* dir);
+    void direction(const wvector1& pos, wvector1* dir) const;
 
     /**
      * Compute the surface area between three points in space.  The distances

--- a/waveq3d/eigenray.h
+++ b/waveq3d/eigenray.h
@@ -80,6 +80,16 @@ struct eigenray {
      * Number of caustics encountered along this path.
      */
     int caustic ;
+
+    /**
+     * Number of upper vertices encountered along this path.
+     */
+    int upper ;
+
+    /**
+     * Number of lower vertices encountered along this path.
+     */
+    int lower ;
 };
 
 /**

--- a/waveq3d/reflection_model.cc
+++ b/waveq3d/reflection_model.cc
@@ -98,9 +98,10 @@ bool reflection_model::bottom_reflection( size_t de, size_t az, double depth ) {
     else { grazing = asin( -dot_full / c ) ; }
 
     // invoke bottom reverberation callback
-    if( _wave.is_ray_valid(de,az) ) {
-        build_eigenverb( de, az, time_water, grazing, c,
-            position, ndirection, BOTTOM ) ;
+
+    if ( _wave._collection ) {
+		_wave.build_eigenverb( de, az, time_water, grazing, c,
+			position, ndirection, usml::eigenverb::eigenverb::BOTTOM ) ;
     }
 
     // compute reflection loss
@@ -163,9 +164,9 @@ bool reflection_model::surface_reflection( size_t de, size_t az ) {
     if ( grazing <= 0.0 ) return false ;	// near miss of the surface
 
     // surface reverberation callback
-    if( _wave.is_ray_valid(de,az) ) {
-        build_eigenverb( de, az, time_water, grazing, c,
-            position, ndirection, SURFACE ) ;
+    if ( _wave._collection ) {
+		_wave.build_eigenverb( de, az, time_water, grazing, c,
+			position, ndirection, usml::eigenverb::eigenverb::SURFACE ) ;
     }
 
     // compute reflection loss
@@ -304,54 +305,4 @@ void reflection_model::reflection_copy(
     element->sound_speed( de, az ) = results.sound_speed(0,0) ;
     element->distance( de, az ) = results.distance(0,0) ;
     element->path_length( de, az ) += results.path_length(0,0) ;
-}
-
-/**
- * Builds the eigenverb used in reverberation calculations
- */
-void reflection_model::build_eigenverb(
-    size_t de, size_t az, double dt, double grazing,
-    double speed, const wposition1& position,
-    const wvector1& ndirection, interface_type type )
-{
-    usml::eigenverb::eigenverb verb ;
-    verb.distance = _wave.curr()->path_length(de,az) + speed * dt ;
-    double true_distance = verb.distance ;
-    double spreading_loss = 1.0 / (true_distance * true_distance) ;
-    vector<double> amp( _wave.frequencies()->size(), spreading_loss ) ;
-    vector<double> boundary_loss = pow( 10.0, -0.1 * _wave.curr()->attenuation(de,az) ) ;
-    verb.intensity = element_prod( amp, boundary_loss ) ;
-
-    // Only continue if the verb meets the threshold intensity
-    if ( verb.intensity(0) > 1e-10 ) {
-        verb.de_index = de ;
-        verb.az_index = az ;
-        verb.launch_az = _wave.source_az(az) ;
-        verb.launch_de = _wave.source_de(de) ;
-        verb.travel_time = _wave.time() + dt ;
-        verb.grazing = grazing ;
-        verb.sound_speed = speed ;
-        verb.position = position ;
-        verb.x = position.longitude() ;
-        verb.y = position.latitude() ;
-        verb.direction = ndirection ;
-        verb.frequencies = _wave.frequencies() ;
-        verb.surface = _wave.curr()->surface(de,az) ;
-        verb.bottom = _wave.curr()->bottom(de,az) ;
-
-        // Calculate the width of the gaussian at the time of impact
-        double delta_de ;
-        if( de == 0 ) {
-            delta_de = M_PI * ( _wave.source_de(de+1) - _wave.source_de(de) ) / 180.0  ;
-        } else {
-            delta_de = M_PI * ( _wave.source_de(de+1) - _wave.source_de(de-1) ) / 360.0  ;
-        }
-        verb.sigma_de = true_distance * delta_de / sin(grazing) ;
-        double delta_az = M_PI * ( _wave.source_az(az+1) - _wave.source_az(az) ) / 180.0 ;
-        verb.sigma_az = delta_az * cos(grazing) * true_distance ;   // horizontal distance * azimuthal spacing
-        if( abs(grazing) > (M_PI_2 - 1e-10) ) verb.sigma_az = TWO_PI * true_distance ;
-
-        // Add the eigenverb to the collection
-        _collection->add_eigenverb( verb, type ) ;
-    }
 }

--- a/waveq3d/reflection_model.h
+++ b/waveq3d/reflection_model.h
@@ -54,9 +54,6 @@ class USML_DECLSPEC reflection_model
     /** Wavefront object associated with this model. */
     wave_queue& _wave ;
 
-    /** Associated eigenverb collection **/
-    eigenverb_collection* _collection ;
-
     /**
      * If the water is too shallow, bottom_reflection() uses a horizontal
      * normal to simulate reflection from "dry land".  Without this, the
@@ -89,7 +86,7 @@ class USML_DECLSPEC reflection_model
      * Hide default constructor to prohibit use by non-friends.
      */
     reflection_model( wave_queue& wave )
-    	: _wave( wave ), _collection( NULL ),
+    	: _wave( wave ),
     	  TOO_SHALLOW( 300.0 * wave._time_step )
     	{}
 
@@ -209,24 +206,6 @@ class USML_DECLSPEC reflection_model
         wave_front* element, size_t de, size_t az,
         wave_front& results ) ;
 
-    /**
-     * Constructs an eigenverb from the data provided. If the eigenverb meets
-     * the intensity threshold, the eigenverb is passed to the collision
-     * listener who then calls its collector to save the eigenverb.
-     *
-     * @param de            D/E angle index number.
-     * @param az            AZ angle index number.
-     * @param dt            Offset in time to collision with the boundary
-     * @param grazing       The grazing angle at point of impact (rads)
-     * @param speed         Speed of sound at the point of collision.
-     * @param position      Location at which the collision occurs
-     * @param ndirection    Normalized direction at the point of collision.
-     * @param type          Interface enumeration for this eigenverb
-     */
-    void build_eigenverb(
-        size_t de, size_t az, double dt, double grazing,
-        double speed, const wposition1& position,
-        const wvector1& ndirection, interface_type type ) ;
 } ;
 
 }  // end of namespace waveq3d

--- a/waveq3d/spreading_hybrid_gaussian.cc
+++ b/waveq3d/spreading_hybrid_gaussian.cc
@@ -31,14 +31,18 @@ spreading_hybrid_gaussian::spreading_hybrid_gaussian(wave_queue& wave) :
         for (size_t a = 0; a < wave.num_az() - 1; ++a) {
             double az1 = to_radians(wave.source_az(a));
             double az2 = to_radians(wave.source_az(a + 1));
-            _norm_az(d, a) = (sin(de2) - sin(de1)) * (az2 - az1) / _norm_de(d);
+            _init_area(d,a) = (sin(de2) - sin(de1)) * (az2 - az1) ;
+            _norm_az(d,a) =  _init_area(d,a) / _norm_de(d);
         }
         _norm_az(d, wave.num_az() - 1) = _norm_az(d, wave.num_az() - 2);
     }
 
     _norm_de(wave.num_de() - 1) = _norm_de(wave.num_de() - 2);
+    size_t n = wave.num_de() - 1 ;
+    size_t m = wave.num_de() - 2 ;
     for (size_t a = 0; a < wave._source_az->size() - 1; ++a) {
-        _norm_az(wave.num_de() - 1, a) = _norm_az(wave.num_de() - 2, a);
+    	_init_area(n,a) = _init_area(m,a) ;
+        _norm_az(n,a) = _norm_az(m,a);
     }
 
     _norm_de /= sqrt(TWO_PI);

--- a/waveq3d/spreading_model.h
+++ b/waveq3d/spreading_model.h
@@ -30,13 +30,21 @@ class USML_DECLSPEC spreading_model {
         vector<double> _spread ;
 
         /**
+         * Initial ensonified area for each ray span. Assign the area for each
+         * span to the index of the ray that precedes it in D/E and azimuth.
+         * Copy the last element in each direction from  the one before it.
+         */
+        matrix<double> _init_area ;
+
+        /**
          * Initializes the spreading model.
          *
          * @param wave          Wavefront object associated with this model.
          * @param num_freqs     Number of different frequencies.
          */
         spreading_model( wave_queue& wave, size_t num_freqs ) :
-            _wave(wave), _spread(num_freqs)
+            _wave(wave), _spread(num_freqs),
+			_init_area(wave.num_de(), wave.num_az())
         {}
 
         /**
@@ -79,6 +87,17 @@ class USML_DECLSPEC spreading_model {
          */
         virtual double width_az(
             size_t de, size_t az, const vector<double>& offset ) = 0 ;
+
+        /**
+         * Initial ensonified area for each ray span. Assign the area for each
+         * span to the index of the ray that precedes it in D/E and azimuth.
+         *
+         * @param   de          DE index of contributing cell.
+         * @param   az          AZ index of contributing cell.
+         */
+        double init_area( size_t de, size_t az ) {
+        	return _init_area(de,az) ;
+        }
 } ;
 
 }  // end of namespace waveq3d

--- a/waveq3d/spreading_ray.cc
+++ b/waveq3d/spreading_ray.cc
@@ -10,8 +10,7 @@ using namespace usml::waveq3d;
  * Estimate initial ensonfied area between rays at radius of 1 meter.
  */
 spreading_ray::spreading_ray(wave_queue& wave) :
-    spreading_model( wave, wave._frequencies->size() ),
-    _init_area(wave.num_de(), wave.num_az())
+    spreading_model( wave, wave._frequencies->size() )
 {
     for (size_t d = 0; d < wave.num_de() - 1; ++d) {
         for (size_t a = 0; a < wave.num_az() - 1; ++a) {
@@ -26,7 +25,7 @@ spreading_ray::spreading_ray(wave_queue& wave) :
     for (size_t a = 0; a < wave._source_az->size() - 1; ++a) {
         _init_area(wave.num_de() - 1, a) = _init_area(wave.num_de() - 2, a);
     }
-    _init_area /= _wave._curr->sound_speed(0, 0);
+    _init_sound_speed = _wave._curr->sound_speed(0, 0);
 }
 
 /**
@@ -95,7 +94,8 @@ const vector<double>& spreading_ray::intensity(
     const double area = (1.0 - u) * area1 + u * area2;
 //    cout << " area1=" << area1 << " area2=" << area2
 //         << " u=" << u << " area=" << area << endl ;
-    const double loss = _init_area(de, az) * sound_speed(0, 0) / area;
+    const double loss = _init_area(de, az) * sound_speed(0, 0) /
+    		( area * _init_sound_speed ) ;
     for (size_t f = 0; f < _wave._frequencies->size(); ++f) {
         _spread(f) = loss ;
     }

--- a/waveq3d/spreading_ray.h
+++ b/waveq3d/spreading_ray.h
@@ -37,13 +37,9 @@ class USML_DECLSPEC spreading_ray : public spreading_model {
   private:
 
     /**
-     * Initial ensonified area for each ray span. Assign the area for each
-     * span to the index of the ray that precedes it in D/E and azimuth.
-     * Copy the last element in each direction from  the one before it.
-     * Divide the initial area by the initial speed of sound so that we
-     * don't have to do this each time intensity is calculated.
+     * Initial speed of sound.
      */
-    matrix<double> _init_area ;
+    double _init_sound_speed ;
 
   protected:
 

--- a/waveq3d/wave_queue.cc
+++ b/waveq3d/wave_queue.cc
@@ -1133,7 +1133,7 @@ void wave_queue::build_eigenverb(
 	// initialize eigenverb
 
     usml::eigenverb::eigenverb verb ;
-    verb.frequencies = this->frequencies() ;
+    verb.frequencies = _frequencies ;
     const size_t num_freq = verb.frequencies->size() ;
 
 	verb.time = time() + dt ;
@@ -1166,10 +1166,7 @@ void wave_queue::build_eigenverb(
     //    - sum squared distance with square of spreading factor
     //    - projects beam onto interface using grazing angle
 
-	vector<double> spreading( verb.frequencies->size() ) ;
-	for ( int f=0 ; f < spreading.size() ; ++f ) {
-		spreading(f) = TWO_PI * speed / (*verb.frequencies)(f) ;
-	}
+	vector<double> spreading = TWO_PI * speed / (*verb.frequencies);
 	const double sg = sin(grazing);
 	const double overlap = 2.0 ;
 	const double path_length = curr()->path_length(de,az)


### PR DESCRIPTION
Evaluate the data types stored in eigenverbs.
- Store total energy faction instead of peak intensity.
- Store direction angle instead of ndirection.
- Store length^2 and width^2 instead of sigma_de and sigma_az.
- No longer using distance, sound_speed
- Added counters for upper and lower to both eigenrays and eigenverb.
- Add counter for caustic to eigenverb.
- Use int instead of size_t for surface,bottom counters because
  that is what we use everywhere else.
- Add a const declaration to void direction(const wvector1& pos, wvector1* dir)
  so it can be used in const methods.

Call detect_volume_scattering() before and after interface scattering.
- Needed to situations where volume scattering layer is near the interface,
  and next() location may change before volume scattering is detected.

Start making length2 and width2 functions of frequency in eigenverb.h
- Move build_eigenverb() from reflection_model to wave_queue.
- Add accessors for spread(), overlap(), and init_area()
  to spreading_model.  Populate with data in both spreading_ray
  and spreading_hybrid_gaussian.

Replace length based estimates in eigenverb generation.
- Compute total energy of each beam instead of using 1/R^2 to estimate
  spreading loss.
- Use _spreading_model->width_de and _az to estimate widths.
- Add init_area() accessor to spreading_model.

Build a scheme for allowing eigenverb_collection to support
multiple volume scattering layers.
- Store all eigenverb_lists in a single vector where the first 4 entries
  are BOTTOM, SURFACE, VOLUME_UPPER, VOLUME_LOWER, and the volume layers
  just repeat.  This prevents us from passing around the type an an enum.
- Update eigenverb_collection::write_netcdf() to support updated list of
  eigenverb attributes.
- Move the interface_type enumeration inside of eigenverb so that the
  documentation will all apear in the same place.

Modify wave_queue debug options
- Add DEBUG_EIGENVERBS to print eigenverbs as they are created.
- Change DEBUG_OUTPUT_EIGENRAYS to DEBUG_EIGENRAYS and make it the
  variable that prints basic information about eigenrays
  as they are created.
- Change DEBUG_EIGENRAYS to DEBUG_EIGENRAYS_DETAIL and make it the option
  to get detailed information about eigenrays.

Fix special cases for eigenverb generation.
- Build a spreading model if you have a least 3 DE and AZ angles,
  but don't check to see if you have targets.
- Only call build_eigenverb if list of eigenverb listeners is not empty.
- Replace use of is_ray_valid with special cases for on_edge DE values
  in build_eigenverb.

First version of eigenverb_basic test that runs to completion.
- Re-test generation of eigenverb netCDF files and update comments
  of eigenverb_collection::write_netcdf().
- Still need to test the accuracy of generated eigenverbs.

Add additional conditions on eigenverb calculation
Exits immediately if:
- An eigenverb listener has not yet been defined.
- The wave has not started to propagate.
- The grazing angle is less than 1e-6 radians.
- The last azimuth of the fan overlaps the first azimuth.
- The launch D/E angle is greater +/- 89.9 degrees.

Results from model now match analytic solution.
- Use a simplified beam width based on path length.
- Use same setup as reflect_flat_test to compute results
  for a round earth with a flat bottom.

Temporarily stub out envelope calculations until we finish testing this.

Resolves issue #130 .