### PR TITLE
New beam pattern model that allows for multiple patterns

### DIFF
--- a/sensors/beam_pattern_multi.cc
+++ b/sensors/beam_pattern_multi.cc
@@ -1,0 +1,66 @@
+/**
+ * @file beam_pattern_multi.cc
+ */
+
+#include <usml/sensors/beam_pattern_multi.h>
+#include <boost/foreach.hpp>
+
+using namespace usml::sensors ;
+using namespace boost ;
+
+/**
+ * Constructor
+ */
+beam_pattern_multi::beam_pattern_multi(
+    std::list<beam_pattern_model*> beam_list )
+    : _beam_list(beam_list)
+{
+
+}
+
+/**
+ * Destructor
+ */
+beam_pattern_multi::~beam_pattern_multi()
+{
+    BOOST_FOREACH( beam_pattern_model* b, _beam_list )
+        delete b ;
+}
+
+/**
+ * Multiplies all beam levels from each beam pattern
+ */
+void beam_pattern_multi::beam_level(
+    double de, double az,
+    orientation& orient,
+    const vector<double>& frequencies,
+    vector<double>* level )
+{
+    write_lock_guard(_mutex) ;
+    vector<double> tmp ;
+    noalias(*level) = vector<double>( frequencies.size(), 1.0 ) ;
+    BOOST_FOREACH( beam_pattern_model* b, _beam_list )
+    {
+        b->beam_level( de, az, orient, frequencies, &tmp ) ;
+        *level = element_prod( *level, tmp ) ;
+    }
+}
+
+/**
+ * Multiplies the directivity indices from each beam pattern
+ */
+void beam_pattern_multi::directivity_index(
+    const vector<double>& frequencies,
+    vector<double>* level )
+{
+    write_lock_guard(_mutex) ;
+    vector<double> tmp ;
+    noalias(*level) = vector<double>( frequencies.size(), 1.0 ) ;
+    BOOST_FOREACH( beam_pattern_model* b, _beam_list )
+    {
+        b->directivity_index( frequencies, &tmp ) ;
+        tmp = pow( 10.0, tmp ) ;
+        *level = element_prod( *level, tmp ) ;
+    }
+    *level = 10.0 * log10( *level ) ;
+}

--- a/sensors/beam_pattern_multi.h
+++ b/sensors/beam_pattern_multi.h
@@ -1,0 +1,65 @@
+/**
+ * @file beam_pattern_multi.h
+ */
+#pragma once
+
+#include <usml/sensors/beam_pattern_model.h>
+#include <list>
+
+namespace usml {
+namespace sensors {
+
+class USML_DECLSPEC beam_pattern_multi
+   : public beam_pattern_model
+{
+
+public:
+
+    /**
+     * Constructor
+     * Takes a list of beam patterns and stores them locally to be used
+     * when requesting a beam level.
+     */
+    beam_pattern_multi( std::list<beam_pattern_model*> beam_list ) ;
+
+    /**
+     * Destructor
+     */
+    virtual ~beam_pattern_multi() ;
+
+    /**
+     * Computes the response level in a specific DE/AZ pair and
+     * beam steering angle. The return, level, is passed
+     * back in linear units.
+     *
+     * @param de            Depression/Elevation angle (rad)
+     * @param az            Azimuthal angle (rad)
+     * @param orient        Orientation of the array
+     * @param frequencies   List of frequencies to compute beam level for
+     * @param level         Beam level for each frequency (linear units)
+     */
+    virtual void beam_level( double de, double az,
+                             orientation& orient,
+                             const vector<double>& frequencies,
+                             vector<double>* level) ;
+
+    /**
+     * Computes the directivity index for a list of frequencies
+     *
+     * @param frequencies   frequencies to determine DI at
+     * @param level         gain for the provided frequencies
+     */
+    virtual void directivity_index( const vector<double>& frequencies,
+                                    vector<double>* level ) ;
+
+private:
+
+    /**
+     * List of beam patterns associated with this multi-pattern
+     */
+    std::list<beam_pattern_model*>  _beam_list ;
+
+};
+
+}   // end of namespace sensors
+}   // end of namespace usml

--- a/sensors/beam_pattern_multi.h
+++ b/sensors/beam_pattern_multi.h
@@ -19,6 +19,9 @@ public:
      * Constructor
      * Takes a list of beam patterns and stores them locally to be used
      * when requesting a beam level.
+     * @param beam_list list of pointers to beam_pattern_model's. This class 
+     *                  takes ownership of the beam_pattern_model pointers,
+     *                  and deletes them on destruction.
      */
     beam_pattern_multi( std::list<beam_pattern_model*> beam_list ) ;
 


### PR DESCRIPTION
Resolves issue #156 
With the addition of this class, a beam pattern can now be constructed from a series of beam patterns. Each pattern is stored in a list within the new class and when beam level is called, the beam level from each pattern in the list is multiplied together and returned. The directivity index is computed in a similar fashion.