### PR TITLE
Wavefront constructor

### DIFF
--- a/eigenverb/wavefront_generator.cc
+++ b/eigenverb/wavefront_generator.cc
@@ -11,7 +11,7 @@ using namespace usml::eigenverb ;
 
 int wavefront_generator::number_de = 181;
 int wavefront_generator::number_az = 18;
-double wavefront_generator::time_maximum = 1.0;          // sec
+double wavefront_generator::time_maximum = 90.0;          // sec
 double wavefront_generator::time_step = 0.01;            // sec
 double wavefront_generator::intensity_threshold = 300.0; // dB
 

--- a/eigenverb/wavefront_generator.cc
+++ b/eigenverb/wavefront_generator.cc
@@ -5,27 +5,56 @@
  *      Author: Ted Burns, AEgis Technologies Group, Inc.
  */
 
-#include <usml/waveq3d/eigenray_collection.h>
 #include <usml/eigenverb/wavefront_generator.h>
 
 using namespace usml::eigenverb ;
 
 int wavefront_generator::number_de = 181;
 int wavefront_generator::number_az = 18;
-double wavefront_generator::pulse_length = 0.5; // sec
-double wavefront_generator::time_step = 0.01; // sec
-double wavefront_generator::time_maximum = 1.0; // sec
+double wavefront_generator::time_maximum = 1.0;          // sec
+double wavefront_generator::time_step = 0.01;            // sec
+double wavefront_generator::intensity_threshold = 300.0; // dB
+
+/**
+ * Constructor
+ */
+wavefront_generator::wavefront_generator(shared_ptr<ocean_model> ocean,
+        wposition1 source_position, wposition target_positions,
+        const seq_vector* frequencies, wavefront_listener* listener,
+        double vertical_beamwidth,  double depression_elevation_angle, int run_id)
+    : _done(false),
+      _run_id(run_id),
+      _number_de(number_de),
+      _number_az(number_az),
+      _time_maximum(time_maximum),
+      _time_step(time_step),
+      _intensity_threshold(intensity_threshold),
+      _depression_elevation_angle(depression_elevation_angle),
+      _vertical_beamwidth(vertical_beamwidth),
+      _source_position(source_position),
+      _target_positions(target_positions),
+      _frequencies(frequencies),
+      _ocean(ocean),
+      _wavefront_listener(listener)
+{
+
+}
 
 /**
  * Default Constructor
  */
 wavefront_generator::wavefront_generator()
-    : _runID(0),
-      _done(false),
-      _range_maximum(0.0),
-      _intensity_threshold(300.0),
+    : _done(false),
+      _run_id(0),
+      _time_maximum(time_maximum),
+      _time_step(time_step),
+      _number_de(number_de),
+      _number_az(number_az),
+      _intensity_threshold(intensity_threshold),
       _depression_elevation_angle(0.0),
       _vertical_beamwidth(0.0),
+      _source_position(NULL),
+      _target_positions(NULL),
       _frequencies(NULL),
       _wavefront_listener(NULL)
 {
@@ -35,8 +64,8 @@ wavefront_generator::wavefront_generator()
 void wavefront_generator::run()
 {
     // For Matlab output
-    const char* ncname_wave = "./generator_wave.nc";
-    const char* ncname_proploss = "./generator_proploss.nc";
+    std::string ncname_wave = "./generator_wave.nc";
+    std::string ncname_proploss = "./generator_proploss.nc";
 #ifdef USML_DEBUG
     bool print_out = true;
 #else
@@ -53,25 +82,36 @@ void wavefront_generator::run()
         return ;
     }
 
+    seq_vector* de;
+
     // Setup DE sequence vector for WaveQ3D
-//    double de_start = _depression_elevation_angle - (_vertical_beamwidth * 0.5f);
-//    double de_end = _depression_elevation_angle + (_vertical_beamwidth * 0.5f);
-//
-//    // Don't go above 90 or below -90
-//    // Add extra 2 degrees on each end
-//    de_start = max(de_start - 2.0, -90.0);
-//    de_end = min(de_end + 2.0, 90.00);
+    // when vertical_beamwidth has been set to a value other than zero.
+    if (_vertical_beamwidth != 0.0) {
+
+        double de_start = _depression_elevation_angle - (_vertical_beamwidth * 0.5f);
+        double de_end = _depression_elevation_angle + (_vertical_beamwidth * 0.5f);
+
+        // Don't go above 90 or below -90
+        // Add extra 2 degrees on each end
+        de_start = max(de_start - 2.0, -90.0);
+        de_end = min(de_end + 2.0, 90.00);
+
+        de = new seq_rayfan(de_start, de_end, _number_de, _depression_elevation_angle);
+
+    } else { // use default values for de and az
+
+        de = new seq_rayfan(-90.0, 90.0, _number_de);
+    }
+
+    seq_linear az(0.0, 180.0, _number_az, true);
 
 
-    seq_rayfan de(-90.0, 90.0, number_de);
+    proploss = new eigenray_collection(*(_frequencies), _source_position, *de, az, _time_step, &_target_positions);
 
-    seq_linear az(0.0, 180.0, number_az, true);
+    wave_queue wqWave(*(_ocean.get()), *(_frequencies), _source_position, *de, az, _time_step, &_target_positions,
+                                                                                                            _run_id);
 
-
-    proploss = new eigenray_collection(*(_frequencies), _sensor_position, de, az, time_step, &_targets);
-
-    wave_queue wqWave(*(_ocean.get()), *(_frequencies), _sensor_position, de, az, time_step, &_targets, _runID,
-                                                                usml::waveq3d::wave_queue::HYBRID_GAUSSIAN);
+    delete de;
 
     wqWave.add_eigenray_listener(proploss);
 
@@ -80,11 +120,11 @@ void wavefront_generator::run()
     if (print_out)
     {
         // Plot the rays.
-        wqWave.init_netcdf(ncname_wave);
+        wqWave.init_netcdf(ncname_wave.c_str());
         wqWave.save_netcdf();
     }
     // propagate rays & record
-    while (wqWave.time() < time_maximum)
+    while (wqWave.time() < _time_maximum)
     {
         wqWave.step();
         if (print_out)
@@ -101,7 +141,7 @@ void wavefront_generator::run()
     proploss->sum_eigenrays();
 
     if (print_out) {
-        proploss->write_netcdf(ncname_proploss);
+        proploss->write_netcdf(ncname_proploss.c_str());
     }
 
     eigenray_collection::reference rays(proploss);

--- a/eigenverb/wavefront_generator.h
+++ b/eigenverb/wavefront_generator.h
@@ -22,7 +22,7 @@ namespace eigenverb {
 using namespace usml::ocean ;
 using namespace usml::threads ;
 using namespace usml::waveq3d ;
-
+using namespace usml::types ;
 
 /// @ingroup eigenverb
 /// @{
@@ -32,9 +32,12 @@ class USML_DECLSPEC wavefront_generator : public thread_task
     public:
 
     /**
-     * Default Constructor
+     * Constructor
+     *  * @param listener pointer to a sensor_listener.
      */
-    wavefront_generator();
+    wavefront_generator(shared_ptr<ocean_model> ocean, wposition1 source_position,
+        wposition target_positions, const seq_vector* frequencies, wavefront_listener* listener,
+        double vertical_beamwidth = 0.0, double depression_elevation_angle = 0.0, int run_id = 0);
 
     /**
      * Virtual destructor
@@ -56,146 +59,88 @@ class USML_DECLSPEC wavefront_generator : public thread_task
     }
 
     /**
-     * Sets runID for the WaveQ3D run.
-     * @param runID
-     */
-    void runID(int runID) {
-        _runID = runID;
-    }
-
-    /**
-     * Sets the maximum range for the WaveQ3D run.
-     * @param range_maximum in meters
-     */
-    void range_maximum(double range_maximum) {
-        _range_maximum = range_maximum;
-    }
-
-    /**
-     * Sets the intensity_threshold for the WaveQ3D run.
-     * @param intensity_threshold in dB
-     */
-    void intensity_threshold(double intensity_threshold) {
-        _intensity_threshold = intensity_threshold;
-    }
-
-    /**
-     * Sets the _depression_elevation_angle for the WaveQ3D run.
-     * @param _depression_elevation_angle in radians
-     */
-    void depression_elevation_angle(double depression_elevation_angle) {
-        _depression_elevation_angle = depression_elevation_angle;
-    }
-
-    /**
-     * Sets the _vertical_beamwidth for the WaveQ3D run.
-     * @param _vertical_beamwidth in radians
-     */
-    void vertical_beamwidth(double vertical_beamwidth) {
-        _vertical_beamwidth = vertical_beamwidth;
-    }
-
-    /**
-     * Sets the _sensor_position for the WaveQ3D run.
-     * @param sensor_position wposition1 type
-     */
-    void sensor_position(wposition1 sensor_position) {
-        _sensor_position = sensor_position;
-    }
-
-    /**
-     * Sets the _targets for the WaveQ3D run.
-     * @param targets wposition container type.
-     */
-    void targets(wposition targets) {
-        _targets = targets;
-    }
-
-    /**
-     * Sets the frequencies for the WaveQ3D run.
-     * @param frequencies pointer to a seq_data type
-     */
-    void frequencies(const seq_vector* frequencies) {
-        _frequencies = frequencies;
-    }
-
-    /**
-     * Sets the ocean for the WaveQ3D run.
-     * @param ocean shared_pointer to an ocean_model
-     */
-    void ocean(shared_ptr<ocean_model> ocean) {
-        _ocean = ocean;
-    }
-
-    /**
-     * Sets the sensor_listener object
-     * @param listener pointer to a sensor_listener.
-     */
-    void wavefront_listener(wavefront_listener* listener) {
-        _wavefront_listener = listener;
-    }
-
-    /**
-     * Pulse length of the signal (sec)
-     */
-    static double pulse_length;
-
-    /**
-     * Maximum time (sec) to propagate WaveQ3D wavefront.
-     */
-    static double time_maximum;
-
-    /**
-     * Maximum time (sec) to propagate WaveQ3D wavefront.
-     */
-    static double time_step;
-
-    /**
-     * Number of depression/elevation angles to use in WaveQ3D wavefront.
+     * Default Number of depression/elevation angles to use in WaveQ3D wavefront.
      */
     static int number_de;
 
     /**
-     * Number of AZ angles to use in WaveQ3D wavefront
+     * Default Number of AZ angles to use in WaveQ3D wavefront
      */
     static int number_az;
+
+     /**
+     * Default Maximum time (sec) to propagate WaveQ3D wavefront.
+     */
+    static double time_maximum;
+
+    /**
+     * Default Maximum time (sec) to propagate WaveQ3D wavefront.
+     */
+    static double time_step;
+
+     /**
+     * The value of the intensity threshold in dB
+     * Any eigenray intensity values that are weaker than this
+     * threshold are stored for later retrieval.
+     */
+    static double intensity_threshold;
 
 private:
 
     /**
-     * The ID for the WaveQ3D run.
+     * Default Constructor - Prevent Access
      */
-    int _runID;
+    wavefront_generator();
+
+     /** Mutex to lock multiple properties at once. */
+    read_write_lock _lock ;
 
     /** Set to true when WaveQ3D propagation model task complete. */
     bool _done ;
 
-    /** Mutex to lock multiple properties at once. */
-    read_write_lock _lock ;
+    /**
+     * The ID for the WaveQ3D run.
+     */
+    const int _run_id;
+
+     /**
+      * Number of depression/elevation angles to use in WaveQ3D wavefront.
+      */
+    const int _number_de;
 
     /**
-     * Maximum range (meters) to propagate WaveQ3D wavefront.
+     * Number of AZ angles to use in WaveQ3D wavefront
      */
-    double  _range_maximum;
+    const int _number_az;
+
+    /**
+     * Maximum time (sec) to propagate WaveQ3D wavefront.
+     */
+    const double _time_maximum;
+
+    /**
+     * Time each step (sec) of WaveQ3D wavefront increases.
+     */
+    const double _time_step;
 
     /**
      * The value of the intensity threshold in dB
      * Any eigenray intensity values that are weaker than this
      * threshold are not sent the eigenray_listner(s);
      */
-    double  _intensity_threshold; //In dB
+    const double _intensity_threshold; //In dB
 
     /** Depression elevation angle in degrees */
-    double  _depression_elevation_angle;
+    const double  _depression_elevation_angle;
 
     /** Vertical beam width in degrees*/
-    double  _vertical_beamwidth;
+    const double  _vertical_beamwidth;
 
-    /** Sensor position */
-    wposition1 _sensor_position;
+    /** Source position */
+    const wposition1 _source_position;
 
     /** Targets container */
-    wposition _targets;
+    const wposition _target_positions;
 
     /** Frequencies container */
     const seq_vector* _frequencies;
@@ -204,7 +149,7 @@ private:
     shared_ptr<ocean_model> _ocean;
 
     /** Pointer to the sensor_listener. */
-    usml::eigenverb::wavefront_listener* _wavefront_listener;
+    wavefront_listener* _wavefront_listener;
 };
 
 /// @}

--- a/eigenverb/wavefront_generator.h
+++ b/eigenverb/wavefront_generator.h
@@ -27,13 +27,46 @@ using namespace usml::types ;
 /// @ingroup eigenverb
 /// @{
 
+/**
+ * This class inherits the thread_task interface and is used to assemble
+ * the all data required by the wave_queue and then run the wave_queue.
+ * Once instantiated the class run method is called by passing its pointer
+ * into the thread_controller's run method.
+ *
+ * Several of the static attributes that can be set prior to constructing
+ * this class are as follows with there default values:
+ *
+ *  wavefront_generator::number_de = 181;              // Number of depression/elevation indices
+ *  wavefront_generator::number_az = 18;               // Number of azimuthal indices
+ *  wavefront_generator::time_maximum = 90.0;          // Max run time seconds
+ *  wavefront_generator::time_step = 0.01;             // Step time i seconds
+ *  wavefront_generator::intensity_threshold = -300.0; // dB  Eigenray with intensity values below this are discarded.
+ */
+
 class USML_DECLSPEC wavefront_generator : public thread_task
 {
     public:
 
     /**
      * Constructor
-     *  * @param listener pointer to a sensor_listener.
+     *
+     *  @param ocean shared pointer to the ocean_model required by the wave_queue
+     *  @param source_position wposition1 type that contains the lat, lon, alt
+     *         of the source sensor.
+     *  @param target_positions wposition type that contains the lat, lon, alt
+     *         of each of the targets.
+     *  @param frequencies pointer to a seq_vector type that contains all the
+     *         freq for wave_queue.
+     *  @param listener pointer to a sensor_listener class that will receive the
+     *         eigenrays and eigenverbs.
+     *  @param vertical_beamwidth in decimal degrees of the sensors beam above and
+     *         below depression_elevation_angle.
+     *         Optional, not used when not provided.
+     *  @param depression_elevation_angle decimal degrees offset from the
+     *         horizontal plane.
+     *         Optional, Defaults to 0 (zero).
+     *  @param run_id ID for this propagation run of wave_queue.
+     *         Optional. Defaults to 0 (zero).
      */
     wavefront_generator(shared_ptr<ocean_model> ocean, wposition1 source_position,
         wposition target_positions, const seq_vector* frequencies, wavefront_listener* listener,

--- a/sensors/fathometer_model.h
+++ b/sensors/fathometer_model.h
@@ -356,7 +356,7 @@ private:
     /**
      * Eigenrays that connect source and receiver locations.
      */
-    boost::shared_ptr<eigenray_list> _eigenrays;
+    shared_ptr<eigenray_list> _eigenrays;
 
 	/**
 	 * Mutex that locks during eigenray access

--- a/sensors/sensor_listener.h
+++ b/sensors/sensor_listener.h
@@ -46,7 +46,7 @@ public:
 	 * @param	sensorID The ID of the sensor that issued the notification.
 	 * @param   eigenray_list Shared pointer to the list of eigenrays
 	 */
-	virtual void update_eigenrays(int sensorID, shared_ptr<eigenray_list> list) = 0;
+	virtual void update_eigenrays(int sensorID, eigenray_list* list) = 0;
 
 	/**
 	 * Notification that new eigenverb data is ready.

--- a/sensors/sensor_manager.cc
+++ b/sensors/sensor_manager.cc
@@ -42,9 +42,6 @@ sensor_manager::~sensor_manager()
     for ( iter = _map.begin(); iter != _map.end(); ++iter )
     {
         sensor_model* sensor = iter->second;
-        #ifdef USML_DEBUG
-            cout << " ~sensor_manager: deleting sensor " << sensor << endl;
-        #endif
         delete sensor;
     }
 }

--- a/sensors/sensor_model.cc
+++ b/sensors/sensor_model.cc
@@ -255,28 +255,19 @@ void sensor_model::run_wave_generator() {
         #ifdef USML_DEBUG
             cout << "sensor_model: run_wave_generator(" << _sensorID << ")" << endl ;
         #endif
-        // Create the wavefront_generator
-        wavefront_generator* generator = new wavefront_generator();
-
-        // Populate waveq3d settings
-        generator->wavefront_listener(this);
-        generator->sensor_position(_position);
 
         // Get the targets sensor references
         std::list<const sensor_model*> targets = sensor_targets();
 
-        // Get the target positions
-        wposition target_pos = target_positions(targets);
-        generator->targets(target_pos);
-
-        // Set the targetID's for later use in sending on to sensor_pair
+        // Store the targetID's for later use in sending on to sensor_pairs
         target_ids(targets);
 
-        // Get the frequencies
-        generator->frequencies(_source->frequencies());
+        // Get the target positions for wavefront_generator
+        wposition target_pos = target_positions(targets);
 
-        // Set the ocean_model
-        generator->ocean(ocean_shared::current());
+        // Create the wavefront_generator
+        wavefront_generator* generator = new wavefront_generator(
+            ocean_shared::current(), _position, target_pos, _source->frequencies(), this);
 
         // Make wavefront_generator a wavefront_task, with use of shared_ptr
         _wavefront_task = thread_task::reference(generator);

--- a/sensors/sensor_model.cc
+++ b/sensors/sensor_model.cc
@@ -126,9 +126,8 @@ void sensor_model::update_eigenrays(eigenray_collection::reference& eigenrays)
             // Get eigenray_list for listener, ie sensor_pair
             // Get complement's row's eigenray_list
             eigenray_list* list = _eigenray_collection->eigenrays(row, 0);
-            shared_ptr<eigenray_list> rays_sptr(list);
              // Send out shared_ptr of eigenray_list to listener
-            listener->update_eigenrays(_sensorID, rays_sptr);
+            listener->update_eigenrays(_sensorID, list);
         }
 	}
 }

--- a/sensors/sensor_model.h
+++ b/sensors/sensor_model.h
@@ -11,7 +11,6 @@
 #include <usml/sensors/orientation.h>
 #include <usml/sensors/source_params.h>
 #include <usml/sensors/xmitRcvModeType.h>
-#include <usml/threads/read_write_lock.h>
 #include <usml/threads/thread_task.h>
 #include <usml/waveq3d/eigenray_collection.h>
 #include <set>

--- a/sensors/sensor_pair.cc
+++ b/sensors/sensor_pair.cc
@@ -9,28 +9,24 @@ using namespace usml::sensors;
 /**
  * Notification that new eigenray data is ready.
  */
-void sensor_pair::update_eigenrays(sensor_model::id_type sensorID, shared_ptr<eigenray_list> list)
+void sensor_pair::update_eigenrays(sensor_model::id_type sensorID, eigenray_list* list)
 {
     write_lock_guard guard(_eigenrays_mutex);
     #ifdef USML_DEBUG
         cout << "sensor_pair: update_eigenrays("
              << sensorID << ")" << endl ;
     #endif
-
+    // Must create a new memory location for eigenrays
+    eigenray_list* new_list = new eigenray_list(*list);
     // If sensor that made this call is the _receiver of this pair
     //    then Swap de's, and az's
     if (sensorID == _receiver->sensorID()) {
-
-        eigenray_list* eigenrays = list.get();
-        BOOST_FOREACH( eigenray ray, *eigenrays) {
+        BOOST_FOREACH( eigenray ray, *new_list) {
             std::swap(ray.source_de, ray.target_de);
             std::swap(ray.source_az, ray.target_az);
         }
     }
-    #ifdef NOOP
-    cout << "sensor_pair: update_eigenrays inserting eigenray_list" << endl ;
-    #endif
-    _eigenrays = list;
+    _eigenrays = shared_ptr<eigenray_list> (new_list);
 }
 
 /**

--- a/sensors/sensor_pair.h
+++ b/sensors/sensor_pair.h
@@ -75,7 +75,7 @@ public:
 	 * @param  sensorID The ID of the sensor that issued the notification.
      * @param  eigenray_list Shared pointer to the list of eigenrays
 	 */
-	virtual void update_eigenrays(sensor_model::id_type sensorID, shared_ptr<eigenray_list> list) ;
+	virtual void update_eigenrays(sensor_model::id_type sensorID, eigenray_list* list) ;
 
 	/**
 	 * Notification that new eigenverb data is ready.

--- a/sensors/sensor_pair_manager.cc
+++ b/sensors/sensor_pair_manager.cc
@@ -44,9 +44,6 @@ sensor_pair_manager::~sensor_pair_manager() {
     for ( iter = _map.begin(); iter != _map.end(); ++iter )
     {
         sensor_pair* pair_data = iter->second;
-        #ifdef USML_DEBUG
-            cout << "  ~sensor_pair_manager: deleting sensor_pair " << pair_data << endl;
-        #endif
         delete pair_data;
     }
 }
@@ -152,10 +149,6 @@ fathometer_model::fathometer_package sensor_pair_manager::get_fathometers(sensor
                 wposition1 src_pos = pair_data->source()->position();
                 wposition1 rcv_pos = pair_data->receiver()->position();
                 fathometer = new fathometer_model(src_id, rcv_id, src_pos, rcv_pos, eigenrays);
-                #ifdef USML_DEBUG
-                    cout << "sensor_pair_manager: get_fathometers - added fathometer for pair "
-                        << "src " << src_id << " rcv " << rcv_id << endl;
-                #endif
                 fathometers.push_back(fathometer);
             }
         }

--- a/studies/reverberation/reverb_analytic_test.cc
+++ b/studies/reverberation/reverb_analytic_test.cc
@@ -161,7 +161,6 @@ private:
         // usml::sensors::BOTH
     	xmitRcvModeType sensor_modes[] = {usml::sensors::BOTH};
 
-
         // Build a query
         sensor_pair_manager::sensor_query_map query;
         for ( int i = 0; i < sizeof(sensor_ids) / sizeof(sensor_model::id_type); ++i ) {

--- a/studies/reverberation/reverb_analytic_test.cc
+++ b/studies/reverberation/reverb_analytic_test.cc
@@ -4,11 +4,13 @@
 #include <usml/ocean/ocean_shared.h>
 #include <usml/sensors/beams.h>
 #include <usml/sensors/sensors.h>
+#include <usml/eigenverb/wavefront_generator.h>
 #include <list>
 #include <boost/progress.hpp>
 #include <boost/foreach.hpp>
 
-using namespace usml::sensors;
+using namespace usml::sensors ;
+using namespace usml::eigenverb ;
 
 /**
  * This scenario compute reverberation for a scenario that has a simple
@@ -135,6 +137,12 @@ private:
 		orientation orient(0.0, 0.0);	// default orientation
 
 		sensor_manager::instance()->add_sensor(sensorID, paramsID, "sensor1");
+
+		// Set wave_queue attributes
+		wavefront_generator::time_maximum = 1.0; // sec
+		wavefront_generator::intensity_threshold = 150.0; //dB
+
+		// Update sensor data and run wave_queue.
 		sensor_manager::instance()->update_sensor(sensorID, pos, orient, true);
 	}
 
@@ -142,7 +150,6 @@ private:
 	 * Wait for the reverberation model to compute results.
 	 *
 	 * TODO Retrieve envelopes from sensor_pair_manager.
-	 * TODO Record results of this test.
 	 */
 	void wait_for_results() {
 


### PR DESCRIPTION
Changed wavefront_generator to have no setters and just take in all
required data in the constructor.

Modified sensor_pair to take in a eigenray_list to update_eigenrays then
clone the list and store as a shared_ptr. This will allow for deletion
of fathometers after get_fathometers is called.