### PR TITLE
Relocate frequencies

### DIFF
--- a/netcdf/netcdf_coards.h
+++ b/netcdf/netcdf_coards.h
@@ -56,46 +56,17 @@ template< class DATA_TYPE, int NUM_DIMS > class netcdf_coards :
             throw std::invalid_argument("NetCDF variable not found");
         }
 
-        // search for linear or logrithmic pattern in this data
-
         const int N = (int) axis->num_vals() ;
-        bool isLinear = true ;
-        bool isLog = true ;
-        boost::numeric::ublas::vector<double> data(N) ;
-
-        double p1 = axis->as_double(0) ; data(0) = p1 ;
-        double minValue = p1 ;
-        double maxValue = p1 ;
-
-        if ( N > 1 ) {
-            double p2 = axis->as_double(1) ; data(1) = p2 ;
-            for ( int n=2 ; n < N ; ++n ) {
-                double p3 = axis->as_double(n) ; data(n) = p3 ;
-                maxValue = p3 ;
-                // printf("diff[%d] = %f\n",n,p3-p2);
-                if ( abs( ((p3-p2)-(p2-p1)) / p2 ) > 1E-4 ) {
-                    isLinear = false ;
-                }
-                if ( p1 == 0.0 || p2 == 0.0 ||
-                    abs( (p3/p2)-(p2/p1) ) > 1E-5 )
-                {
-                    isLog = false ;
-                }
-                if ( ! ( isLinear || isLog ) ) break ;
-                p1 = p2 ;
-                p2 = p3 ;
-            }
+        std::vector<double> data(N);
+    
+        // Convert to std::vector
+        for ( int n = 0; n < N; ++n ) {
+            data.push_back(axis->as_double(n));
         }
 
-        // build a new sequence for this axis
-
-        cout << axis->name() << " N=" << N << " minValue=" << minValue << " maxValue=" << maxValue << endl ;
-        if ( isLinear ) {
-            return new seq_linear( minValue, (maxValue-minValue)/(N-1), N ) ;
-        } else if ( isLog ) {
-            return new seq_log( minValue, (maxValue/minValue)/(N-1), N ) ;
-        }
-        return new seq_data( data ) ;
+        // build and return 
+        // best fit for seq_linear or seq_log or worst case seq_data
+        return  seq_vector::build_best(data); 
     }
 
   public:

--- a/netcdf/netcdf_coards.h
+++ b/netcdf/netcdf_coards.h
@@ -57,16 +57,17 @@ template< class DATA_TYPE, int NUM_DIMS > class netcdf_coards :
         }
 
         const int N = (int) axis->num_vals() ;
-        std::vector<double> data(N);
-    
+        std::vector<double> data;
+
         // Convert to std::vector
         for ( int n = 0; n < N; ++n ) {
-            data.push_back(axis->as_double(n));
+            double p = axis->as_double(n);
+            data.push_back(p);
         }
 
-        // build and return 
+        // build and return
         // best fit for seq_linear or seq_log or worst case seq_data
-        return  seq_vector::build_best(data); 
+        return  seq_vector::build_best(data);
     }
 
   public:

--- a/sensors/fathometer_model.cc
+++ b/sensors/fathometer_model.cc
@@ -23,14 +23,13 @@ void fathometer_model::write_netcdf( const char* filename, const char* long_name
     nc_file->add_att("Conventions", "COARDS");
 
     // Get the list to get the frequency size
-    eigenray_list* eigenrays = _eigenrays.get();
-    long num_frequencies = ( long ) eigenrays->front().frequencies->size();
+    long num_frequencies = ( long ) _eigenrays.front().frequencies->size();
 
     // dimensions
 
     NcDim *freq_dim = nc_file->add_dim("frequency", num_frequencies);
     NcVar *freq_var = nc_file->add_var("frequency", ncDouble, freq_dim);
-    NcDim *eigenray_dim = nc_file->add_dim("eigenrays", ( long ) eigenrays->size());
+    NcDim *eigenray_dim = nc_file->add_dim("eigenrays", ( long ) _eigenrays.size());
    
     // fathometer_model attributes
 
@@ -99,7 +98,7 @@ void fathometer_model::write_netcdf( const char* filename, const char* long_name
     
     // write base attributes
 
-    freq_var->put(eigenrays->front().frequencies->data().begin(), num_frequencies);
+    freq_var->put(_eigenrays.front().frequencies->data().begin(), num_frequencies);
     item = _source_id; source_id->put(&item, 1);
     item = _receiver_id; receiver_id->put(&item, 1); 
 
@@ -119,7 +118,7 @@ void fathometer_model::write_netcdf( const char* filename, const char* long_name
     v = _receiver_position.longitude();   rcv_lng_var->put(&v, 1);
     v = _receiver_position.altitude();    rcv_alt_var->put(&v, 1);
 
-    BOOST_FOREACH(eigenray ray, *eigenrays)
+    BOOST_FOREACH(eigenray ray, _eigenrays)
     {
         // set record number for each eigenray data element
 

--- a/sensors/fathometer_model.h
+++ b/sensors/fathometer_model.h
@@ -44,7 +44,7 @@ public:
      * @param   eigenrays   Shared Pointer to the eigenray list.
      */
     fathometer_model(sensor_model::id_type source_id, sensor_model::id_type receiver_id,
-                     wposition1 src_pos, wposition1 rcv_pos, shared_ptr<eigenray_list> list )
+                     wposition1 src_pos, wposition1 rcv_pos, eigenray_list list )
         : _source_id(source_id), _receiver_id(receiver_id), _slant_range(0.0), 
         _distance_from_sensor(0.0), _depth_offset_from_sensor(0.0),
         _source_position(src_pos), _receiver_position(rcv_pos), _eigenrays(list)
@@ -170,21 +170,21 @@ public:
     }
 
 	/**
-     * Gets the shared_ptr to last eigenray_list update for this fathometer_model.
-     * @return  eigenray_list shared_ptr
+     * Gets the eigenray_list for this fathometer_model.
+     * @return  eigenray_list
      */
-    boost::shared_ptr<eigenray_list> eigenrays() {
+    eigenray_list eigenrays() {
          read_lock_guard guard(_eigenrays_mutex);
          return _eigenrays;
     }
 
     /**
-     * Sets the shared_ptr to eigenray_list for this fathometer_model.
-     * @return  eigenray_list shared_ptr to the eigenray_list
+     * Sets the eigenray_list for this fathometer_model.
+     * @param  eigenray_list
      */
-    void eigenrays(eigenray_list* list) {
+    void eigenrays(eigenray_list list) {
          write_lock_guard guard(_eigenrays_mutex);
-         _eigenrays = boost::shared_ptr<eigenray_list>(list);
+         _eigenrays = list;
     }
 
     /**
@@ -356,7 +356,7 @@ private:
     /**
      * Eigenrays that connect source and receiver locations.
      */
-    shared_ptr<eigenray_list> _eigenrays;
+    eigenray_list _eigenrays;
 
 	/**
 	 * Mutex that locks during eigenray access

--- a/sensors/fathometer_model.h
+++ b/sensors/fathometer_model.h
@@ -44,7 +44,7 @@ public:
      * @param   eigenrays   Shared Pointer to the eigenray list.
      */
     fathometer_model(sensor_model::id_type source_id, sensor_model::id_type receiver_id,
-                     wposition1 src_pos, wposition1 rcv_pos, eigenray_list list )
+                     wposition1 src_pos, wposition1 rcv_pos, const eigenray_list& list )
         : _source_id(source_id), _receiver_id(receiver_id), _slant_range(0.0), 
         _distance_from_sensor(0.0), _depth_offset_from_sensor(0.0),
         _source_position(src_pos), _receiver_position(rcv_pos), _eigenrays(list)

--- a/sensors/receiver_params.cc
+++ b/sensors/receiver_params.cc
@@ -10,24 +10,8 @@ using namespace usml::sensors;
  * Construct new class of receiver.
  */
 receiver_params::receiver_params(sensor_params::id_type paramsID, 
-    const seq_vector& frequencies, 
+    double min_freq, double max_freq, const seq_vector& frequencies, 
     const std::list<beam_pattern_model::id_type>& beamList, bool multistatic)
-    : sensor_params(paramsID, frequencies, multistatic), _beam_list(beamList)
+    : sensor_params(paramsID, min_freq, max_freq, frequencies, beamList, multistatic)
 {
-
-}
-
-/**
- * Searchs the beam pattern list for a specific beam pattern
- * with the requested ID
- */
-beam_pattern_model::reference receiver_params::beam_pattern(
-        beam_pattern_model::id_type beamID ) const
-{
-    if( std::find(_beam_list.begin(), _beam_list.end(), beamID)
-        == _beam_list.end() )
-    {
-        return beam_pattern_model::reference() ;
-    }
-    return beam_pattern_map::instance()->find(beamID) ;
 }

--- a/sensors/receiver_params.h
+++ b/sensors/receiver_params.h
@@ -5,9 +5,7 @@
 #pragma once
 
 #include <usml/sensors/sensor_params.h>
-#include <usml/sensors/beam_pattern_map.h>
-#include <algorithm>
-#include <list>
+
 
 namespace usml {
 namespace sensors {
@@ -34,65 +32,40 @@ public:
 	typedef shared_ptr<receiver_params> reference;
 
 	/**
-	 * Data type used for store beam patterns in this sensor.
-	 */
-	typedef std::list<beam_pattern_model::id_type> beam_pattern_list ;
-
-	/**
 	 * Construct new class of receiver.
 	 *
 	 * @param	paramsID	    Identification used to find this sensor type
 	 * 						    in receiver_params_map.
+     * @param	min_freq		Minimum active frequency for the sensor. Lower
+     *                          active bound of the sensor.
+     * @param	max_freq		Maximum active frequency for the sensor. Upper
+     *                          active bound of the sensor.
      * @param	frequencies		Operating frequencies that this sensor will listen.
      * 							This is cloned during construction.
-	 * @param   beamList	    List of beamIds associated with this receiver class.
-	 * 						    The actual beams are extracted from beam_pattern_map
-	 * 						    using these beamIDs.
+	 * @param   beam_list	    List of beamIds associated with this sensor.
+     * 						    The actual beams are extracted from beam_pattern_map
+     * 						    using these beamIDs.
      * @param   multistatic	    Optional. Defaults to true. 
      *                          When true, this receiver will pair up with
 	 * 						    all other sources in the reverberation model.
 	 * 						    When false, it will only pair up with its own source.
 	 */
-    receiver_params(sensor_params::id_type paramsID, const seq_vector& frequencies,
-        const beam_pattern_list& beamList, bool multistatic = true);
+    receiver_params(sensor_params::id_type paramsID, double min_freq, 
+        double max_freq, const seq_vector& frequencies, 
+        const beam_pattern_list& beam_list, bool multistatic = true);
 
 	/**
 	 * Clone receiver parameters from an existing receiver class.
 	 */
-	receiver_params(const receiver_params& other) ;
+    receiver_params(const receiver_params& other)
+        : sensor_params(other) 
+    {}
 
 	/**
 	 * Virtual destructor
 	 */
 	virtual ~receiver_params() {
 	}
-
-	/**
-	 * Const reference to the beam pattern container.
-	 */
-	size_t num_patterns() const {
-		return _beam_list.size() ;
-	}
-
-	/**
-	 * Shared reference to a single beam in the pattern pattern.
-	 */
-	beam_pattern_model::reference beam_pattern( beam_pattern_model::id_type beamID ) const ;
-
-	/**
-	 * Const reference to the beam pattern container.
-	 */
-	const beam_pattern_list& beam_list() const {
-		return _beam_list ;
-	}
-
-private:
-
-	/**
-	 * List of all beam pattern IDs associated with this receiver
-	 * parameter.
-	 */
-	beam_pattern_list _beam_list ;
 };
 
 /// @}

--- a/sensors/sensor_listener.h
+++ b/sensors/sensor_listener.h
@@ -44,9 +44,9 @@ public:
 	 * Notification that new eigenray data is ready.
 	 *
 	 * @param	sensorID The ID of the sensor that issued the notification.
-	 * @param   eigenray_list Shared pointer to the list of eigenrays
+	 * @param   eigenray_list pointer to std::list of eigenrays
 	 */
-	virtual void update_eigenrays(int sensorID, eigenray_list* list) = 0;
+	virtual void update_fathometer(int sensorID, eigenray_list* list) = 0;
 
 	/**
 	 * Notification that new eigenverb data is ready.

--- a/sensors/sensor_model.cc
+++ b/sensors/sensor_model.cc
@@ -290,13 +290,8 @@ void sensor_model::select_frequencies() {
     if ( band_max  > max ) {
         max = band_max;
     }
-
-    #ifdef USML_DEBUG
-        cout << "sensor_model: _frequencies min " << min << " max " << max << " size " << band_size << endl;
-    #endif
     
-    _frequencies.reset(new seq_linear(min, max, band_size, true));
-
+    _frequencies.reset(new seq_linear(min, (max-min)/band_size, max));
 }
 
 

--- a/sensors/sensor_model.h
+++ b/sensors/sensor_model.h
@@ -75,12 +75,28 @@ public:
 	}
 
     /**
+     * Gets the minimum active frequency
+     * @return double 
+     */
+    double min_active_freq() const {
+        return _min_active_freq;
+    }
+
+    /**
+     * Gets the maximum active frequency
+     * @return double
+     */
+    double max_active_freq() const {
+        return _max_active_freq;
+    }
+
+    /**
      * Frequencies of transmitted pulse. Multiple frequencies can be
      * used to compute multiple results at the same time. These are the
      * frequencies at which transmission loss and reverberation are computed.
-     * @return frequencies pointer to a seq_linear. 
+     * @return frequencies pointer to a seq_vector. 
      */
-    const seq_linear* frequencies() const {
+    seq_vector* frequencies() const {
         return _frequencies.get();
     }
 
@@ -206,10 +222,10 @@ private:
 	void run_wave_generator();
 
     /**
-     * Utility to select frequencies band from sensor including
+     * Utility to set the frequencies band from sensor including
      * min and max active frequencies.
      */
-    void select_frequencies();
+    void frequencies();
 
 	/**
 	 * Identification used to find this sensor instance in sensor_manager.
@@ -222,11 +238,21 @@ private:
 	const sensor_params::id_type _paramsID;
 
     /**
+     * Minimum active frequency for the sensor.
+     */
+    double _min_active_freq;
+
+    /**
+     *  Maximum active frequency for the sensor.
+     */
+    double _max_active_freq;
+
+    /**
      * Frequencies of transmitted pulse. Multiple frequencies can be
      * used to compute multiple results at the same time. These are the
      * frequencies at which transmission loss and reverberation are computed.
      */
-    unique_ptr<seq_linear> _frequencies;
+    unique_ptr<seq_vector> _frequencies;
 
     /**
      * Enumerated type for the sensor transmit/receiver mode.

--- a/sensors/sensor_model.h
+++ b/sensors/sensor_model.h
@@ -67,11 +67,22 @@ public:
 	}
 
 	/**
-	 * Identification used to lookup sensor type data in source_params_map and receiver_params_map.
+	 * Identification used to lookup sensor type data in 
+     * source_params_map and receiver_params_map.
 	 */
 	sensor_params::id_type paramsID() const {
 		return _paramsID;
 	}
+
+    /**
+     * Frequencies of transmitted pulse. Multiple frequencies can be
+     * used to compute multiple results at the same time. These are the
+     * frequencies at which transmission loss and reverberation are computed.
+     * @return frequencies pointer to a seq_linear. 
+     */
+    const seq_linear* frequencies() const {
+        return _frequencies.get();
+    }
 
 	/**
 	 * Human readable name for this sensor instance.
@@ -158,7 +169,7 @@ public:
 private:
 
 	/**
-	 * Checks to see if new position and orientation have changed enough
+	 * Utility to check if new position and orientation have changed enough
 	 * to require a new WaveQ3D run.
 	 *
 	 * @param position  	Updated position data
@@ -170,29 +181,35 @@ private:
 			const orientation& orientation );
 
 	/**
-	 * Queries the current list of sensor listeners for the complements
+	 * Utility to query the current list of sensor listeners for the complements
 	 * of this sensor. Assumes that these listeners act like sensor_pair objects.
 	 * @return list of sensor_model pointers that are the complements of the this sensor.
 	 */
 	std::list<const sensor_model*> sensor_targets();
 
 	/**
-	 * Sets the list of target sensorID's from the list of sensors provided.
+	 * Utility to set the list of target sensorID's from the list of sensors provided.
 	 * @params list of sensor_model pointers.
 	 */
 	void target_ids(std::list<const sensor_model*>& list);
 
 	/**
-	 * Builds a list of target positions from the input list of sensors provided.
+	 * Utility to builds a list of target positions from the input list of sensors provided.
 	 * @params list of sensor_model pointers.
 	 * @return wposition container of positions of the list of sensors provided.
 	 */
 	wposition target_positions(std::list<const sensor_model*>& list);
 
 	/**
-	 * Run the wave_generator thread task to start the waveq3d model.
+	 * Utility to run the wave_generator thread task to start the waveq3d model.
 	 */
 	void run_wave_generator();
+
+    /**
+     * Utility to select frequencies band from sensor including
+     * min and max active frequencies.
+     */
+    void select_frequencies();
 
 	/**
 	 * Identification used to find this sensor instance in sensor_manager.
@@ -203,6 +220,13 @@ private:
 	 * Identification used to lookup sensor type data in source_params_map and receiver_params_map.
 	 */
 	const sensor_params::id_type _paramsID;
+
+    /**
+     * Frequencies of transmitted pulse. Multiple frequencies can be
+     * used to compute multiple results at the same time. These are the
+     * frequencies at which transmission loss and reverberation are computed.
+     */
+    unique_ptr<seq_linear> _frequencies;
 
     /**
      * Enumerated type for the sensor transmit/receiver mode.
@@ -274,7 +298,7 @@ private:
 	/**
 	 * List containing the references of objects that will be used to
 	 * update classes that require sensor data.
-	 * These classes must implement update_eigenrays and update_eigenverbs methods.
+	 * These classes must implement update_fathometer and update_eigenverbs methods.
 	 */
 	std::list<sensor_listener*> _sensor_listeners;
 

--- a/sensors/sensor_pair.cc
+++ b/sensors/sensor_pair.cc
@@ -7,6 +7,25 @@
 using namespace usml::sensors;
 
 /**
+* Utility to build the intersecting frequencies of a sensor_pair.
+*/
+void sensor_pair::frequencies() {
+
+    // Build intersecting frequencies
+    _frequencies = _source->frequencies()->clip(
+        _receiver->min_active_freq(), _receiver->max_active_freq());
+
+    // Get first and last values
+    double first_value = *( _frequencies->begin() );
+    double last_value = *( _frequencies->end() - 1 );
+   
+    // Set first and last index's
+    _src_freq_first = _source->frequencies()->find_index(first_value);
+    _src_freq_last = _source->frequencies()->find_index(last_value);
+}
+
+
+/**
  * Notification that new eigenray data is ready.
  */
 void sensor_pair::update_fathometer(sensor_model::id_type sensorID, eigenray_list* list)

--- a/sensors/sensor_pair.cc
+++ b/sensors/sensor_pair.cc
@@ -9,24 +9,27 @@ using namespace usml::sensors;
 /**
  * Notification that new eigenray data is ready.
  */
-void sensor_pair::update_eigenrays(sensor_model::id_type sensorID, eigenray_list* list)
+void sensor_pair::update_fathometer(sensor_model::id_type sensorID, eigenray_list* list)
 {
-    write_lock_guard guard(_eigenrays_mutex);
+    write_lock_guard guard(_fathometer_mutex);
     #ifdef USML_DEBUG
-        cout << "sensor_pair: update_eigenrays("
+        cout << "sensor_pair: update_fathometer("
              << sensorID << ")" << endl ;
     #endif
-    // Must create a new memory location for eigenrays
-    eigenray_list* new_list = new eigenray_list(*list);
+   
     // If sensor that made this call is the _receiver of this pair
     //    then Swap de's, and az's
-    if (sensorID == _receiver->sensorID()) {
-        BOOST_FOREACH( eigenray ray, *new_list) {
-            std::swap(ray.source_de, ray.target_de);
-            std::swap(ray.source_az, ray.target_az);
+    if ( list != NULL ) {
+        if (sensorID == _receiver->sensorID()) {
+            BOOST_FOREACH(eigenray ray, *list) {
+                std::swap(ray.source_de, ray.target_de);
+                std::swap(ray.source_az, ray.target_az);
+            }
         }
+        // Note new memory location for eigenrays is create here
+        _fathometer = shared_ptr<fathometer_model>(new fathometer_model(_source->sensorID(), 
+            _receiver->sensorID(), _source->position(), _receiver->position(), *list));
     }
-    _eigenrays = shared_ptr<eigenray_list> (new_list);
 }
 
 /**

--- a/sensors/sensor_pair.h
+++ b/sensors/sensor_pair.h
@@ -37,16 +37,25 @@ public:
      *
      * @param	source		Pointer to the source for this pair.
      * @param	receiver	Pointer to the receiver for this pair.
-     * @param	frequencies	std::vector of doubles of 
-     *                      intersecting frequencies for this pair.
      */
-    sensor_pair(sensor_model* source, sensor_model* receiver, std::vector<double> frequencies)
-        : _source(source), _receiver(receiver), _frequencies(frequencies) {};
+    sensor_pair(sensor_model* source, sensor_model* receiver)
+        : _source(source), _receiver(receiver)
+    {
+        if ( _source->mode() == usml::sensors::BOTH ) {
+            _frequencies = _source->frequencies()->clone();
+            _src_freq_first = 0;
+            _src_freq_last = _source->frequencies()->size()-1;
+        } else {
+            frequencies();
+        }
+    };
 
     /**
      * Default Destructor
      */
-    virtual ~sensor_pair() {}
+    virtual ~sensor_pair() {
+        delete _frequencies;
+    }
 
     /**
      * Gets a pointer to the source sensor.
@@ -65,10 +74,10 @@ public:
     }
 
     /**
-     * The intersecting frequencies of both the _source and _reciever sensors.
-     * @return frequencies in a std::vector of doubles.
+     * The intersecting frequencies from the _source for this pair.
+     * @return frequencies 
      */
-    std::vector<double> frequencies() const {
+    const seq_vector* frequencies() const {
         return _frequencies;
     }
 
@@ -116,6 +125,23 @@ private:
     sensor_pair() {};
 
     /**
+     * Utility to build the intersecting frequencies of a sensor_pair.
+     */
+    void frequencies();
+
+    /**
+     * Index of the first intersecting frequency of the 
+     * source frequencies seq_vector;
+     */
+    size_t _src_freq_first;
+
+    /**
+     * Index of the last intersecting frequency of the
+     * source frequencies seq_vector;
+     */
+    size_t _src_freq_last;
+
+    /**
      * Pointer to the source sensor.
      * The source and receiver will be equal for monostatic sensors.
      */
@@ -128,9 +154,10 @@ private:
     const sensor_model* _receiver;
 
     /**
-     * The intersecting frequencies of both the _source and _reciever sensors
+     * The intersecting frequencies from the _source of t
+     * the _source and _reciever sensors.
      */
-    const std::vector<double> _frequencies;
+    const seq_vector* _frequencies;
 
     /**
      * Mutex that locks sensor_pair during complement lookups.

--- a/sensors/sensor_pair_manager.cc
+++ b/sensors/sensor_pair_manager.cc
@@ -443,12 +443,7 @@ bool sensor_pair_manager::remove_sensor(sensor_model* sensor) {
 void sensor_pair_manager::add_monostatic_pair(sensor_model* sensor) {
 	sensor_model::id_type sourceID = sensor->sensorID();
     std::string hash_key = generate_hash_key(sourceID, sourceID);
-    std::vector<double> frequencies;
-    const seq_vector* seq_freq = sensor->source()->frequencies();
-    BOOST_FOREACH(double freq, *seq_freq) {
-        frequencies.push_back(freq);
-    }
-    sensor_pair* pair = new sensor_pair(sensor, sensor, frequencies);
+    sensor_pair* pair = new sensor_pair(sensor, sensor); 
 	_map.insert(hash_key, pair);
 	sensor->add_sensor_listener(pair);
 	#ifdef USML_DEBUG
@@ -471,9 +466,7 @@ void sensor_pair_manager::add_multistatic_source(sensor_model* source) {
                                         receiver_sensor->receiver()->frequencies()) )
 			{
                 std::string hash_key = generate_hash_key(sourceID, receiverID);
-                sensor_pair* pair = new sensor_pair(source, receiver_sensor, 
-                    build_frequencies(source->source()->frequencies(),
-                    receiver_sensor->receiver()->frequencies()));
+                sensor_pair* pair = new sensor_pair(source, receiver_sensor);
                 _map.insert(hash_key, pair);
 				source->add_sensor_listener(pair);
                 receiver_sensor->add_sensor_listener(pair);
@@ -500,9 +493,7 @@ void sensor_pair_manager::add_multistatic_receiver(sensor_model* receiver) {
                                         receiver->receiver()->frequencies() ) )
 			{
                 std::string hash_key = generate_hash_key(sourceID, receiverID);
-                sensor_pair* pair = new sensor_pair(source_sensor, receiver, 
-                    build_frequencies(source_sensor->source()->frequencies(),
-                    receiver->receiver()->frequencies()));
+                sensor_pair* pair = new sensor_pair(source_sensor, receiver);
                 _map.insert(hash_key, pair);
                 source_sensor->add_sensor_listener(pair);
 				receiver->add_sensor_listener(pair);
@@ -619,26 +610,3 @@ bool sensor_pair_manager::frequencies_overlap(const seq_vector* src_freq, const 
 
     return overlap;
 }
-
-/**
-* Utility to build the intersecting frequencies of a sensor_pair.
-* Stored in the sensor_pair.
-*/
-std::vector<double> sensor_pair_manager::build_frequencies(const seq_vector* src_freq, const seq_vector* rcv_freq) {
-    
-    std::vector<double> frequencies;
-
-    // Get source min and max
-    double src_min = *( src_freq->data().begin() );
-    double src_max = *(src_freq->data().end() - 1);
-    
-    BOOST_FOREACH(double rcv_f, *rcv_freq) {
-
-        if ( ( rcv_f >= src_min ) && ( rcv_f <= src_max ) ) {
-            frequencies.push_back(rcv_f);
-        }
-    }
-
-    return frequencies;
-}
-

--- a/sensors/sensor_pair_manager.cc
+++ b/sensors/sensor_pair_manager.cc
@@ -448,13 +448,6 @@ void sensor_pair_manager::add_monostatic_pair(sensor_model* sensor) {
     BOOST_FOREACH(double freq, *seq_freq) {
         frequencies.push_back(freq);
     }
-    #ifdef USML_DEBUG
-        cout << "   add_monostatic_pair:  frequencies";
-        BOOST_FOREACH(double f, frequencies) {
-            cout << " " << f;
-        }
-        cout << endl;
-    #endif
     sensor_pair* pair = new sensor_pair(sensor, sensor, frequencies);
 	_map.insert(hash_key, pair);
 	sensor->add_sensor_listener(pair);
@@ -645,14 +638,6 @@ std::vector<double> sensor_pair_manager::build_frequencies(const seq_vector* src
             frequencies.push_back(rcv_f);
         }
     }
-
-    #ifdef USML_DEBUG
-        cout << "   build_frequencies:  size " << frequencies.size();
-        BOOST_FOREACH(double f, frequencies) {
-            cout << " " << f ;
-        }
-        cout << endl;
-    #endif
 
     return frequencies;
 }

--- a/sensors/sensor_pair_manager.h
+++ b/sensors/sensor_pair_manager.h
@@ -313,12 +313,20 @@ private:
 
     /**
      * Utility to determine if two frequency ranges overlap
-     * Used to determine of a sensor_pair needs to be created.
+     * Used to determine if a sensor_pair needs to be created.
      * @param	src_freq  frequency range for source
      * @param	rcv_freq  frequenc range for receiver
      * @return  true when frequency ranges overlap
      */
     bool frequencies_overlap(const seq_vector* src_freq, const seq_vector* rcv_freq);
+
+    /**
+     * Utility to build the intersecting frequencies of a sensor_pair.
+     * @param	src_freq  frequency range for source
+     * @param	rcv_freq  frequenc range for receiver
+     * @return frequencies in a std::vector of doubles.
+     */
+    std::vector<double> build_frequencies(const seq_vector* src_freq, const seq_vector* rcv_freq);
 
 	/**
 	 * Hide access to default constructor.

--- a/sensors/sensor_pair_manager.h
+++ b/sensors/sensor_pair_manager.h
@@ -320,14 +320,6 @@ private:
      */
     bool frequencies_overlap(const seq_vector* src_freq, const seq_vector* rcv_freq);
 
-    /**
-     * Utility to build the intersecting frequencies of a sensor_pair.
-     * @param	src_freq  frequency range for source
-     * @param	rcv_freq  frequenc range for receiver
-     * @return frequencies in a std::vector of doubles.
-     */
-    std::vector<double> build_frequencies(const seq_vector* src_freq, const seq_vector* rcv_freq);
-
 	/**
 	 * Hide access to default constructor.
 	 */

--- a/sensors/sensor_params.h
+++ b/sensors/sensor_params.h
@@ -138,7 +138,7 @@ protected:
 	 * 						    for sources and receivers that have this flag
 	 * 							set to true. Set to false for monostatic sensors.
 	 */
-    sensor_params(sensor_params::id_type paramsID, double max_freq, double min_freq, 
+    sensor_params(sensor_params::id_type paramsID, double min_freq, double max_freq,
         const seq_vector& frequencies, const beam_pattern_list& beam_list, 
         bool multistatic = true)
         : _paramsID(paramsID), _min_active_freq( min_freq), _max_active_freq(max_freq),

--- a/sensors/sensor_params.h
+++ b/sensors/sensor_params.h
@@ -4,10 +4,14 @@
  */
 #pragma once
 
+#include <list>
+
 #include <usml/threads/smart_ptr.h>
 
 #include <usml/usml_config.h>
 #include <usml/types/seq_vector.h>
+#include <usml/sensors/beam_pattern_model.h>
+#include <usml/sensors/beam_pattern_map.h>
 
 namespace usml {
 namespace sensors {
@@ -30,6 +34,11 @@ public:
 	 */
 	typedef int id_type;
 
+    /**
+     * Data type used for store beam patterns in this sensor.
+     */
+    typedef std::list<beam_pattern_model::id_type> beam_pattern_list;
+
 	/**
 	 * Identification used to find this sensor type in
 	 * source_params_map and/or receiver_params_map.
@@ -39,12 +48,58 @@ public:
 	}
 
     /**
+     * Gets the minimum active frequency of the sensor. 
+     * Lower active bound of the sensor.
+     * @return minium active frequency of the sensor.
+     */
+    double min_active_freq()  {
+        return _min_active_freq;
+    }
+
+    /**
+    * Gets the maximum active frequency of the sensor.
+    * Upper active bound of the sensor.
+    * @return maxium active frequency of the sensor.
+    */
+    double max_active_freq() {
+        return _max_active_freq;
+    }
+
+    /**
      * Frequencies of transmitted pulse. Multiple frequencies can be
      * used to compute multiple results at the same time. These are the
      * frequencies at which transmission loss and reverberation are computed.
      */
     const seq_vector* frequencies() const {
         return _frequencies.get();
+    }
+
+    /**
+     * Const reference to the beam pattern container.
+     */
+    size_t num_patterns() const {
+        return _beam_list.size();
+    }
+
+    /**
+     * Const reference to the beam pattern container.
+     */
+    const beam_pattern_list& beam_list() const {
+        return _beam_list;
+    }
+
+    /**
+     * Searchs the beam pattern list for a specific beam pattern
+     * with the requested ID
+     * @param beamID ID for the beam_pattern to return.
+     * @return beam_pattern shared pointer
+     */
+    beam_pattern_model::reference beam_pattern(beam_pattern_model::id_type beamID) const {
+        if ( std::find(_beam_list.begin(), _beam_list.end(), beamID)
+            == _beam_list.end() ) {
+            return beam_pattern_model::reference();
+        }
+        return beam_pattern_map::instance()->find(beamID);
     }
 
 	/**
@@ -62,25 +117,44 @@ protected:
 	 *
 	 * @param	paramsID		Identification used to find this sensor type in
 	 * 							source_params_map and/or receiver_params_map.
+     * @param	min_freq		Minimum active frequency for the sensor. Lower
+     *                          active bound of the sensor.
+     * @param	max_freq		Maximum active frequency for the sensor. Upper
+     *                          active bound of the sensor.
      * @param	frequencies		Frequencies of transmitted pulse.
      * 							Multiple frequencies can be used to compute
-     * 							multiple results at the same time.
+     * 						    multiple results at the same time.
      * 							These are the frequencies at which transmission
      * 							loss and reverberation are computed.
      * 							This is cloned during construction.
+     * @param   beam_list	    List of beamIds associated with this sensor.
+     * 						    The actual beams are extracted from beam_pattern_map
+     * 						    using these beamIDs.
 	 * @param	multistatic		Optional. Defaults to true.
-     *                          Only requires setting for sensor's with that 
+     *                          Only requires setting for sensor's in which 
      *                          the mode is BOTH. Must be set true for sensor's
      *                          of mode SOURCE or RECEIVER.
      *                          Bistatic sensor_pair objects are only created
-	 * 							for sources and receivers that have this flag
-	 * 							set to true.  Set to false for monostatic sensors.
+	 * 						    for sources and receivers that have this flag
+	 * 							set to true. Set to false for monostatic sensors.
 	 */
-    sensor_params(sensor_params::id_type paramsID, const seq_vector& frequencies, 
+    sensor_params(sensor_params::id_type paramsID, double max_freq, double min_freq, 
+        const seq_vector& frequencies, const beam_pattern_list& beam_list, 
         bool multistatic = true)
-        : _paramsID(paramsID), _frequencies(frequencies.clone()), _multistatic(multistatic)
+        : _paramsID(paramsID), _min_active_freq( min_freq), _max_active_freq(max_freq),
+        _frequencies(frequencies.clone()), _beam_list(beam_list),
+        _multistatic(multistatic)
 	{
 	}
+
+    /**
+     * Clone sensor parameters from an existing sensor.
+     */
+    sensor_params(const sensor_params& other)
+        : _paramsID(other._paramsID), _min_active_freq(other._min_active_freq),
+        _max_active_freq(other._max_active_freq), _frequencies(other._frequencies.get()),
+        _beam_list(other._beam_list), _multistatic(other._multistatic) 
+    {}
 
 private:
 
@@ -91,11 +165,27 @@ private:
 	sensor_params::id_type _paramsID;
 
     /**
+     * Minimum active frequency for the sensor.
+     */
+    double _min_active_freq;
+
+    /**
+     *  Maximum active frequency for the sensor.
+     */
+    double _max_active_freq;
+
+    /**
      * Frequencies of transmitted pulse. Multiple frequencies can be
      * used to compute multiple results at the same time. These are the
      * frequencies at which transmission loss and reverberation are computed.
      */
     const unique_ptr<seq_vector> _frequencies;
+
+    /**
+     * List of all beam pattern IDs associated with this receiver
+     * parameter.
+     */
+    beam_pattern_list _beam_list;
 
 	/**
 	 * Bistatic sensor_pair objects are only created for sources and receivers

--- a/sensors/source_params.cc
+++ b/sensors/source_params.cc
@@ -3,8 +3,6 @@
  * Sensor characteristics for the source behaviors of a sensor.
  */
 #include <usml/sensors/source_params.h>
-#include <usml/sensors/beam_pattern_map.h>
-#include <algorithm>
 
 using namespace usml::sensors ;
 
@@ -12,11 +10,9 @@ using namespace usml::sensors ;
  * Construct new class of source.
  */
 source_params::source_params( sensor_params::id_type paramsID,
-	vector<double> source_level, const seq_vector& frequencies,
-    beam_pattern_model::id_type beamID, bool multistatic)
-    : sensor_params(paramsID, frequencies, multistatic),
-  _source_level( source_level ),
-  _beam_pattern( beam_pattern_map::instance()->find(beamID) )
+	vector<double> source_level, double min_freq, double max_freq, 
+    const seq_vector& frequencies, const beam_pattern_list& beam_list, bool multistatic)
+    : sensor_params(paramsID, min_freq, max_freq, frequencies, beam_list, multistatic),
+  _source_level( source_level )
 {
-
 }

--- a/sensors/source_params.h
+++ b/sensors/source_params.h
@@ -5,7 +5,6 @@
 #pragma once
 
 #include <usml/sensors/sensor_params.h>
-#include <usml/sensors/beam_pattern_model.h>
 
 using namespace boost::numeric::ublas ;
 
@@ -42,27 +41,33 @@ public:
 	 * 							source_params_map and/or receiver_params_map.
 	 * @param   source_level	Peak intensity of the transmitted pulse
 	 * 							(dB//uPa@1m)
+     * @param	min_freq		Minimum active frequency for the sensor. Lower
+     *                          active bound of the sensor.
+     * @param	max_freq		Maximum active frequency for the sensor. Upper
+     *                          active bound of the sensor.
 	 * @param	frequencies		Frequencies of transmitted pulse.
 	 * 							Multiple frequencies can be used to compute
 	 * 							multiple results at the same time.
 	 * 							These are the frequencies at which transmission
 	 * 							loss and reverberation are computed.
 	 * 							This is cloned during construction.
-	 * @param   beamID			Reference to the beam pattern used during
-	 * 							transmission.  Will be NULL if beamID is not
-	 * 							found in beam_pattern_map.
+	 * @param   beam_list	    List of beamIds associated with this sensor.
+     * 						    The actual beams are extracted from beam_pattern_map
+     * 						    using these beamIDs.
      * @param	multistatic		Optional, defaults to true. 
      *                          Bistatic sensor_pair objects are only created
 	 * 							for sources and receivers that have this flag
 	 * 							set to true.  Set to false for monostatic sensors.
 	 */
 	source_params( sensor_params::id_type paramsID, vector<double> source_level,
-            const seq_vector& frequencies, beam_pattern_model::id_type beamID, 
-            bool multistatic = true);
+            double min_freq, double max_freq, const seq_vector& frequencies, 
+            const beam_pattern_list& beam_list, bool multistatic = true);
 	/**
 	 * Clone source parameters from an existing source class.
 	 */
-	source_params(const source_params& other) ;
+    source_params(const source_params& other)
+        : sensor_params(other), _source_level(other._source_level) 
+    {}
 
 	/**
 	 * Virtual destructor
@@ -77,24 +82,12 @@ public:
 		return _source_level ;
 	}
 
-	/**
-	 * Shared reference to the beam patterns for this source.
-	 */
-	beam_pattern_model::reference beam_pattern() const {
-		return _beam_pattern ;
-	}
-
 private:
 
 	/**
 	 * Peak intensity of the transmitted pulse (dB//uPa@1m)
 	 */
 	const vector<double> _source_level;
-
-	/**
-	 * Shared reference to the beam patterns for this source.
-	 */
-	const beam_pattern_model::reference _beam_pattern;
 };
 
 /// @}

--- a/sensors/test/maps_test.cc
+++ b/sensors/test/maps_test.cc
@@ -69,6 +69,10 @@ BOOST_AUTO_TEST_CASE(source_params_test) {
 
 	cout << "=== maps_test: source_params_test ===" << endl;
 
+    std::list<beam_pattern_model::id_type> beamList;
+    beamList.push_back(beam_pattern_model::OMNI);
+    beamList.push_back(beam_pattern_model::COSINE);
+
 	source_params_map* source_map = source_params_map::instance();
 
     // Source frequencies 6.5K, 7.5K, 8.5K, 9.5K
@@ -78,20 +82,22 @@ BOOST_AUTO_TEST_CASE(source_params_test) {
 	sensor_params::id_type id1 = 1 ;
 	source_params::reference source1( new source_params(
 		id1, 		// paramsID
-		vector<double> (1, 123.0),		// source_level
+		vector<double> (1, 123.0), // source_level
+        7000.0, 10000.0,           // min, max active freq
         source_frequencies,
-		0,          // beamID
-        false));	// multistatic	
+        beamList,                  // beam_list
+        false));	               // multistatic	
 	source_map->insert(source1->paramsID(), source1);
 
 	// setup sensor #2 with bad beam pattern
 
 	sensor_params::id_type id2 = 2 ;
 	source_params::reference source2( new source_params(
-		id2, 		// paramsID		
-		vector<double> (1, 321.0),		// source_level
+		id2, 		                // paramsID		
+		vector<double> (1, 321.0),	// source_level
+        6000.0, 9000.0,             // min, max active freq
         source_frequencies,
-		999)); 		// beamID   // multistatic defaults true
+        beamList)); 		        // beam_list   // multistatic defaults true
 	source_map->insert(source2->paramsID(), source2);
 
 	// test retrieval
@@ -103,10 +109,10 @@ BOOST_AUTO_TEST_CASE(source_params_test) {
 
 	// check beam patterns
 
-	beam_pattern_model::reference bpm1 = spm1->beam_pattern() ;
-	beam_pattern_model::reference bpm2 = spm2->beam_pattern() ;
+	beam_pattern_model::reference bpm1 = spm1->beam_pattern(0) ;
+	beam_pattern_model::reference bpm2 = spm2->beam_pattern(1) ;
 	BOOST_CHECK_EQUAL(bpm1->beamID(), 0);
-	BOOST_CHECK_EQUAL(bpm2.get(), (beam_pattern_model*) 0);
+    BOOST_CHECK_EQUAL(bpm2->beamID(), 1);
 
 	// cleanup inserted source_params so that other tests start fresh
 
@@ -139,7 +145,8 @@ BOOST_AUTO_TEST_CASE(receiver_params_test) {
 
 	sensor_params::id_type id1 = 1 ;
 	receiver_params::reference receiver1( new receiver_params(
-		id1, 		// paramsID
+		id1, 		    // paramsID
+        5000.0, 10000,  // min, max active freq
         receiver_frequencies,
         beamList,
         false));   // multistatic
@@ -149,9 +156,10 @@ BOOST_AUTO_TEST_CASE(receiver_params_test) {
 
 	sensor_params::id_type id2 = 2 ;
 	receiver_params::reference receiver2( new receiver_params(
-		id2, 		// paramsID
+		id2, 		     // paramsID
+        2000.0, 9000.0,  // min, max active freq
         receiver_frequencies,
-		beamList)); // multistatic defaults true
+		beamList));      // multistatic defaults true
 	receiver_map->insert(receiver2->paramsID(), receiver2);
 
 	// test retrieval
@@ -201,10 +209,11 @@ BOOST_AUTO_TEST_CASE(sensor_test) {
 
 	sensor_params::id_type params1 = 12 ;
 	source_params::reference source1( new source_params(
-		params1,	// paramsID
-		vector<double> (1, 123.0),		// source_level
+		params1,	                // paramsID
+		vector<double> (1, 123.0),	// source_level
+        7000.0, 10000.0,            // min, max active freq
         source_frequencies,
-        0));  		// beamID
+        beamList));  		        // beam_list
 	source_params_map::instance()->insert(source1->paramsID(), source1);
 	sensor_model::id_type id1 = 101 ;
 	sensor_mgr->add_sensor(id1, params1, "source_101");
@@ -213,7 +222,8 @@ BOOST_AUTO_TEST_CASE(sensor_test) {
 
 	sensor_params::id_type params2 = 21 ;
 	receiver_params::reference receiver2( new receiver_params(
-		params2,	// paramsID
+		params2,	            // paramsID
+        5000.0, 9000.0,         // min, max active freq
         receiver_frequencies,
 		beamList));
 	receiver_params_map::instance()->insert(receiver2->paramsID(), receiver2);

--- a/sensors/test/sensor_manager_test.cc
+++ b/sensors/test/sensor_manager_test.cc
@@ -125,15 +125,14 @@ BOOST_AUTO_TEST_CASE(pairs_test)
          BOOST_FAIL("pairs_test:: Removed non-existent sensor_model");
     }
 
+    // Check min, max active frequency manipulation
     // Get Frequencies of sensor_model
     sensor_model* sensor_three = manager->find(3);
     const seq_linear* freq = sensor_three->frequencies();   
-
-    cout << "   sensor_three freq:  size " << freq->size();
-    BOOST_FOREACH(double f, *freq) {
-        cout << " " << f;
-    }
-    cout << endl;
+    BOOST_CHECK_EQUAL((*freq)(1), 7375.0);
+    BOOST_CHECK_EQUAL((*freq)(2), 8250.0);
+    BOOST_CHECK_EQUAL((*freq)(3), 9125.0);
+    BOOST_CHECK_EQUAL((*freq)(4), 10000.0);
 
     //cout << "=== pairs_test: remove_sensor 1 BOTH ===" << endl;
     if ( manager->remove_sensor(sensors[0]) == false )
@@ -178,18 +177,6 @@ BOOST_AUTO_TEST_CASE(pairs_test)
         sensor_pair_manager::instance()->get_fathometers(query);
 
     cout << "=== pairs_test: fathometers return size " << fathometers.size() << endl;
-    
-    int index = 0;
-    std::string ncname = USML_TEST_DIR "/sensors/test/fathometers_";
-    std::stringstream fatho_filename;
-    fathometer_model::fathometer_package::iterator iter;
-    for ( iter = fathometers.begin(); iter != fathometers.end(); ++iter ) 
-    {
-        fathometer_model* model = (*iter);
-        fatho_filename.clear();
-        fatho_filename << ncname << index++ << ".nc";
-        model->write_netcdf(fatho_filename.str().c_str(), "");
-    }
 
     // Clean up all singleton to prevent use by other tests!
     source_params_map::reset();

--- a/sensors/test/sensor_manager_test.cc
+++ b/sensors/test/sensor_manager_test.cc
@@ -125,15 +125,6 @@ BOOST_AUTO_TEST_CASE(pairs_test)
          BOOST_FAIL("pairs_test:: Removed non-existent sensor_model");
     }
 
-    // Check min, max active frequency manipulation
-    // Get Frequencies of sensor_model
-    sensor_model* sensor_three = manager->find(3);
-    const seq_linear* freq = sensor_three->frequencies();   
-    BOOST_CHECK_EQUAL((*freq)(1), 7375.0);
-    BOOST_CHECK_EQUAL((*freq)(2), 8250.0);
-    BOOST_CHECK_EQUAL((*freq)(3), 9125.0);
-    BOOST_CHECK_EQUAL((*freq)(4), 10000.0);
-
     //cout << "=== pairs_test: remove_sensor 1 BOTH ===" << endl;
     if ( manager->remove_sensor(sensors[0]) == false )
     {
@@ -176,7 +167,9 @@ BOOST_AUTO_TEST_CASE(pairs_test)
     fathometer_model::fathometer_package fathometers = 
         sensor_pair_manager::instance()->get_fathometers(query);
 
-    cout << "=== pairs_test: fathometers return size " << fathometers.size() << endl;
+    // Expect zero fathometer for this test!
+    BOOST_CHECK_EQUAL(fathometers.size(), 0);
+    //cout << "=== pairs_test: fathometers return size " << fathometers.size() << endl;
 
     // Clean up all singleton to prevent use by other tests!
     source_params_map::reset();

--- a/sensors/test/sensor_manager_test.cc
+++ b/sensors/test/sensor_manager_test.cc
@@ -41,22 +41,24 @@ BOOST_AUTO_TEST_CASE(pairs_test)
 
     // Source frequencies 6.5K, 7.5K, 8.5K, 9.5K
     seq_linear source_frequencies(6500.0, 1000.0, 4);
-    // Receiver frequencies 3.0K, 10.0K
-    seq_linear receiver_frequencies(3000.0, 7000.0, 2);
+    // Receiver frequencies 3.0K, 4.0K, 5.0K, 6.0K, 7.0K, 8.0K, 9.0K, 10.0K
+    seq_linear receiver_frequencies(3000, 1000.0, 7);
 
     // setup SOURCE sensor type  #12 with omni beam pattern
     sensor_params::id_type params1 = 12;
     source_params::reference source1(new source_params(
-        params1,	// paramsID
-        vector<double> (1, 123.0),		// source_level
+        params1,	                // paramsID
+        vector<double> (1, 123.0),	// source_level
+        7000.0, 10000.0,            // min, max active freq
         source_frequencies,
-        0));		// beamID
+        beamList));		           // beam_list
     source_params_map::instance()->insert(source1->paramsID(), source1);
 
     // setup RECEIVER sensor type #21 
     sensor_params::id_type params2 = 21;
     receiver_params::reference receiver1(new receiver_params(
-        params2,	// paramsID
+        params2,	            // paramsID
+        5000.0, 9000.0,         // min, max active freq
         receiver_frequencies,
         beamList));
     receiver_params_map::instance()->insert(receiver1->paramsID(), receiver1);
@@ -65,34 +67,38 @@ BOOST_AUTO_TEST_CASE(pairs_test)
     // setup source side of sensor type #33  BOTH with omni beam pattern
     sensor_params::id_type params3 = 33;
     source_params::reference source3(new source_params(
-        params3,	// paramsID
-        vector<double> (1, 130.0),		// source_level
+        params3,	                // paramsID
+        vector<double> (1, 130.0),  // source_level
+        7000.0, 10000.0,            // min, max active freq
         source_frequencies,
-        0,   		// beamID
-        false));	// not multistatic
+        beamList,   		        // beam_list
+        false));	                // not multistatic
     source_params_map::instance()->insert(source3->paramsID(), source3);
 
     // setup receiver side of sensor type #33 BOTH with beam pattern's 0 and 1
     receiver_params::reference receiver3(new receiver_params(
-        params3,	// paramsID
+        params3,	            // paramsID
+        5000.0, 9000.0,         // min, max active freq
         receiver_frequencies,
         beamList,
-        false));	// not multistatic
+        false));	            // not multistatic
     receiver_params_map::instance()->insert(receiver3->paramsID(), receiver3);
 
     // Vary source and or reciever mutlistatic flag's to test 
     // setup source side of sensor type #44 BOTH with omni beam pattern
     sensor_params::id_type params4 = 44;
     source_params::reference source4(new source_params(
-        params4,	// paramsID	
+        params4,	                    // paramsID	
         vector<double> (1, 130.0),		// source_level
+        6000.0, 9000.0,                 // min, max active freq
         source_frequencies,
-        0,  		// beamID
-        true));     // multistatic flag - vary to test different combo's
+        beamList,  		                // beamID's
+        true));                         // multistatic flag - vary to test different combo's
     source_params_map::instance()->insert(source4->paramsID(), source4);
     // setup receiver side of sensor type #44 with beam pattern's 0 and 1
     receiver_params::reference receiver4(new receiver_params(
         params4,	// paramsID
+        5000.0, 9000.0,         // min, max active freq
         receiver_frequencies,
         beamList,
         true));     // multistatic flag - vary to test different combo's
@@ -118,6 +124,16 @@ BOOST_AUTO_TEST_CASE(pairs_test)
     if ( manager->remove_sensor(2) != false ) {
          BOOST_FAIL("pairs_test:: Removed non-existent sensor_model");
     }
+
+    // Get Frequencies of sensor_model
+    sensor_model* sensor_three = manager->find(3);
+    const seq_linear* freq = sensor_three->frequencies();   
+
+    cout << "   sensor_three freq:  size " << freq->size();
+    BOOST_FOREACH(double f, *freq) {
+        cout << " " << f;
+    }
+    cout << endl;
 
     //cout << "=== pairs_test: remove_sensor 1 BOTH ===" << endl;
     if ( manager->remove_sensor(sensors[0]) == false )

--- a/studies/reverberation/reverb_analytic_test.cc
+++ b/studies/reverberation/reverb_analytic_test.cc
@@ -192,7 +192,6 @@ private:
         }
         cout << "waited for " << timer.elapsed() << " secs" << endl ;
 
-        int index = 0;
         std::string ncname = USML_STUDIES_DIR "/reverberation/fathometer_";
         fathometer_model::fathometer_package::iterator iter;
         for ( iter = fathometers.begin(); iter != fathometers.end(); ++iter )

--- a/studies/reverberation/reverb_analytic_test.cc
+++ b/studies/reverberation/reverb_analytic_test.cc
@@ -103,15 +103,19 @@ private:
 		vector<double> source_level(1, 200.0);
         // Source frequencies 6.5K, 7.5K, 8.5K, 9.5K
 		seq_linear source_frequencies(6500.0, 1000.0, 4);
+        beam_pattern_model::id_type omni = 0;
+        std::list<beam_pattern_model::id_type> source_beams;
+        source_beams.push_back(omni);
+
         // Receiver frequencies 3.0K, 10.0K
         seq_linear receiver_frequencies(3000.0, 7000.0, 2);
-		beam_pattern_model::id_type omni = 0;
-
+		
 		// define source parameters
 
 		source_params::reference source(
 				new source_params(paramsID, source_level,
-                source_frequencies, omni, multistatic));
+                6000.0, 9000.0,             // min, max active freq
+                source_frequencies, source_beams, multistatic));
 		source_params_map::instance()->insert(source->paramsID(), source);
 
 		// define receiver parameters
@@ -120,7 +124,9 @@ private:
 		receiver_beams.push_back(omni);
 
 		receiver_params::reference receiver(
-            new receiver_params(paramsID, receiver_frequencies, receiver_beams, multistatic));
+            new receiver_params(paramsID, 
+            3000.0, 10000.0,  // min, max active freq
+            receiver_frequencies, receiver_beams, multistatic));
 		receiver_params_map::instance()->insert(receiver->paramsID(), receiver);
 	}
 
@@ -206,10 +212,7 @@ private:
         std::string ncname_all = USML_STUDIES_DIR "/reverberation/fathometers.nc";
         sp_man->write_fathometers(fathometers, ncname_all.c_str());
 
-		// Delete all for valgrind memcheck testing
-        BOOST_FOREACH(fathometer_model* fathometer, fathometers) {
-            delete fathometer;
-        }
+        // No need to delete fathometers as they are shared_ptr's
 	}
 };
 

--- a/types/seq_vector.cc
+++ b/types/seq_vector.cc
@@ -1,0 +1,111 @@
+/*
+ * @file seq_vector.cc
+ * A read-only, monotonic sequence of values.
+ */
+#include <usml/types/seq_vector.h>
+
+#include <boost/foreach.hpp>
+#include <usml/types/seq_data.h>
+#include <usml/types/seq_linear.h>
+#include <usml/types/seq_log.h>
+
+using namespace usml::types;
+
+/**
+ * Clips the current seq_vector based on the intersection of the min
+ * and max values provided. Creates and returns new seq_vector using
+ * the build_best method. Caller is responsible to delete the returned
+ * pointer.
+ */
+seq_vector::self_type* seq_vector::clip(double min, double max) const {
+
+    size_t index = -1;
+    double* data = new double[size() - 1];
+    BOOST_FOREACH(double value, *this) {
+        ++index;
+        if ( ( value >= min ) && ( value <= max ) ) {
+            data[index] = value;
+        }
+    }
+    self_type* seq = build_best(data, index);
+    delete[] data;
+    return seq;
+}
+
+/**
+ * Builds the best seq_vector pointer from seq_data, seq_linear or seq_log
+ * based on the contents of the array.
+ */
+seq_vector::self_type* seq_vector::build_best(double* data, size_t count) {
+
+    bool isLinear = true;
+    bool isLog = true;
+   
+    const int N = ( int ) count;
+    double p1 = data[0];
+    double minValue = p1;
+    double maxValue = p1;
+
+    if ( N > 1 ) {
+        double p2 = data[1];
+        for ( int n = 2; n < N; ++n ) {
+            double p3 = data[n];
+            maxValue = p3;
+            // printf("diff[%d] = %f\n",n,p3-p2);
+            if ( abs(( ( p3 - p2 ) - ( p2 - p1 ) ) / p2) > 1E-4 ) {
+                isLinear = false;
+            }
+            if ( p1 == 0.0 || p2 == 0.0 ||
+                abs(( p3 / p2 ) - ( p2 / p1 )) > 1E-5 ) {
+                isLog = false;
+            }
+            if ( !( isLinear || isLog ) ) break;
+            p1 = p2;
+            p2 = p3;
+        }
+    }
+
+    // build a new seq_vector sub type
+    cout << "seq_vector::build_best " << " N=" << N << " minValue=" << minValue << " maxValue=" << maxValue << endl;
+    if ( isLinear ) {
+        return new seq_linear(minValue, ( maxValue - minValue ) / ( N - 1 ), N);
+    }
+    else if ( isLog ) {
+        return new seq_log(minValue, ( maxValue / minValue ) / ( N - 1 ), N);
+    }
+    return new seq_data(data, count);
+}
+
+/**
+ * Builds the best seq_vector pointer from seq_data, seq_linear or seq_log
+ * based on the contents of the ublas vector.
+ */
+seq_vector::self_type* seq_vector::build_best(boost::numeric::ublas::vector<double> data) {
+ 
+    double* data_array = new double[data.size() - 1];
+    size_t index = -1;
+    BOOST_FOREACH(double value, data) {
+        ++index;
+        data_array[index] = value;
+    }
+    self_type* seq = build_best(data_array, index);
+    delete[] data_array;
+    return seq;
+}
+
+/**
+ * Builds the best seq_vector pointer from seq_data, seq_linear or seq_log
+ * based on the contents of the std::vector.
+ */
+seq_vector::self_type* seq_vector::build_best(std::vector<double> data) {
+
+    double* data_array = new double[data.size() - 1];
+    size_t index = -1;
+    BOOST_FOREACH(double value, data) {
+        ++index;
+        data_array[index] = value;
+    }
+    self_type* seq = build_best(data_array, index);
+    delete[] data_array;
+    return seq;
+}

--- a/types/seq_vector.cc
+++ b/types/seq_vector.cc
@@ -4,7 +4,6 @@
  */
 #include <usml/types/seq_vector.h>
 
-#include <iostream>
 #include <boost/foreach.hpp>
 #include <usml/types/seq_data.h>
 #include <usml/types/seq_linear.h>
@@ -25,8 +24,8 @@ seq_vector::self_type* seq_vector::clip(double min, double max) const {
     BOOST_FOREACH(double value, *this) {
         if ( ( value >= min ) && ( value <= max ) ) {
             data[index] = value;
+             ++index;
         }
-        ++index;
     }
     self_type* seq = build_best(data, index);
     delete[] data;
@@ -49,10 +48,10 @@ seq_vector::self_type* seq_vector::build_best(double* data, size_t count) {
 
     if ( N > 1 ) {
         double p2 = data[1];
+        maxValue = p2;
         for ( int n = 2; n < N; ++n ) {
             double p3 = data[n];
             maxValue = p3;
-             //printf("diff[%d] = %f\n",n,p3-p2);
             if ( abs(( ( p3 - p2 ) - ( p2 - p1 ) ) / p2) > 1E-4 ) {
                 isLinear = false;
             }
@@ -65,9 +64,6 @@ seq_vector::self_type* seq_vector::build_best(double* data, size_t count) {
             p2 = p3;
         }
     }
-
-//    cout << "seq_vector::build_best " << " N=" << N <<
-//        " minValue=" << minValue << " maxValue=" << maxValue << endl;
 
     // build a new seq_vector sub type
     if ( isLinear ) {

--- a/types/seq_vector.cc
+++ b/types/seq_vector.cc
@@ -4,6 +4,7 @@
  */
 #include <usml/types/seq_vector.h>
 
+#include <iostream>
 #include <boost/foreach.hpp>
 #include <usml/types/seq_data.h>
 #include <usml/types/seq_linear.h>
@@ -19,13 +20,13 @@ using namespace usml::types;
  */
 seq_vector::self_type* seq_vector::clip(double min, double max) const {
 
-    size_t index = -1;
+    size_t index = 0;
     double* data = new double[size() - 1];
     BOOST_FOREACH(double value, *this) {
-        ++index;
         if ( ( value >= min ) && ( value <= max ) ) {
             data[index] = value;
         }
+        ++index;
     }
     self_type* seq = build_best(data, index);
     delete[] data;
@@ -51,7 +52,7 @@ seq_vector::self_type* seq_vector::build_best(double* data, size_t count) {
         for ( int n = 2; n < N; ++n ) {
             double p3 = data[n];
             maxValue = p3;
-            // printf("diff[%d] = %f\n",n,p3-p2);
+             //printf("diff[%d] = %f\n",n,p3-p2);
             if ( abs(( ( p3 - p2 ) - ( p2 - p1 ) ) / p2) > 1E-4 ) {
                 isLinear = false;
             }
@@ -65,8 +66,10 @@ seq_vector::self_type* seq_vector::build_best(double* data, size_t count) {
         }
     }
 
+//    cout << "seq_vector::build_best " << " N=" << N <<
+//        " minValue=" << minValue << " maxValue=" << maxValue << endl;
+
     // build a new seq_vector sub type
-    cout << "seq_vector::build_best " << " N=" << N << " minValue=" << minValue << " maxValue=" << maxValue << endl;
     if ( isLinear ) {
         return new seq_linear(minValue, ( maxValue - minValue ) / ( N - 1 ), N);
     }
@@ -82,11 +85,11 @@ seq_vector::self_type* seq_vector::build_best(double* data, size_t count) {
  */
 seq_vector::self_type* seq_vector::build_best(boost::numeric::ublas::vector<double> data) {
  
-    double* data_array = new double[data.size() - 1];
-    size_t index = -1;
+    double* data_array = new double[data.size()-1];
+    size_t index = 0;
     BOOST_FOREACH(double value, data) {
-        ++index;
         data_array[index] = value;
+         ++index;
     }
     self_type* seq = build_best(data_array, index);
     delete[] data_array;
@@ -99,11 +102,11 @@ seq_vector::self_type* seq_vector::build_best(boost::numeric::ublas::vector<doub
  */
 seq_vector::self_type* seq_vector::build_best(std::vector<double> data) {
 
-    double* data_array = new double[data.size() - 1];
-    size_t index = -1;
+    double* data_array = new double[data.size()-1];
+    size_t index = 0;
     BOOST_FOREACH(double value, data) {
-        ++index;
         data_array[index] = value;
+        ++index;
     }
     self_type* seq = build_best(data_array, index);
     delete[] data_array;

--- a/types/seq_vector.h
+++ b/types/seq_vector.h
@@ -202,8 +202,6 @@ class USML_DECLSPEC seq_vector: public vector_container<seq_vector>
               _max_index(other._max_index)
         {}
 
-        self_type* build_best_helper(void* data) const;
-
         /**
          * Cache of sequence values.
          */

--- a/types/seq_vector.h
+++ b/types/seq_vector.h
@@ -144,6 +144,42 @@ class USML_DECLSPEC seq_vector: public vector_container<seq_vector>
             return const_iterator (*this, i);
         }
 
+        /**
+         * Clips the current seq_vector based on the intersection of the min 
+         * and max values provided. Creates and returns new seq_vector using 
+         * the build_best method. Caller is responsible to delete the returned
+         * pointer.
+         * @param   min       The element number to retrieve (zero indexed).
+         * @param   max       The element number to retrieve (zero indexed).
+         * @return  pointer to a new clipped seq_vector.            
+         */
+        self_type* clip(double min, double max) const;
+
+        /**
+         * Builds the best seq_vector pointer from seq_data, seq_linear or seq_log 
+         * based on the contents of the array.
+         * @param   data      Pointer to an array of doubles
+         * @param   count     Size of the array
+         * @return  pointer to a seq_data, seq_linear or seq_log
+         */
+        static self_type* build_best(double* data, size_t count);  
+
+        /**
+         * Builds the best seq_vector pointer from seq_data, seq_linear or seq_log
+         * based on the contents of the ublas vector.
+         * @param   data      boost::numeric::ublas::vector<double>
+         * @return  pointer to a seq_data, seq_linear or seq_log
+         */
+        static self_type* build_best(boost::numeric::ublas::vector<double> data);
+
+        /**
+         * Builds the best seq_vector pointer from seq_data, seq_linear or seq_log
+         * based on the contents of the std::vector.
+         * @param   data      std::vector<double>
+         * @return  pointer to a seq_data, seq_linear or seq_log
+         */
+        static self_type* build_best(std::vector<double> data);
+
     protected:
 
         /**
@@ -165,6 +201,8 @@ class USML_DECLSPEC seq_vector: public vector_container<seq_vector>
               _data(other._data), _increment(other._increment),
               _max_index(other._max_index)
         {}
+
+        self_type* build_best_helper(void* data) const;
 
         /**
          * Cache of sequence values.

--- a/types/test/sequence_test.cc
+++ b/types/test/sequence_test.cc
@@ -521,4 +521,52 @@ BOOST_AUTO_TEST_CASE( seq_ublas_test ) {
     delete[] d ;
 }
 
+/**
+ * Tests the seq_vector::clip method
+ */
+BOOST_AUTO_TEST_CASE( seq_vector_clip_test ) {
+    cout << "=== sequence_test/seq_vector_clip_test ===" << endl ;
+
+     // 6.5K, 7.5K, 8.5K, 9.5K
+    seq_linear values(6500.0, 1000.0, 4);
+
+    // Max Clip
+    seq_vector* clipped_values_one = values.clip(5000.0, 9000.0);
+
+    BOOST_CHECK_EQUAL( clipped_values_one->size(), 3 ) ;
+
+    double test_value = (*clipped_values_one)(0);
+    BOOST_CHECK_EQUAL( test_value, 6500 ) ;
+    test_value = (*clipped_values_one)(1);
+    BOOST_CHECK_EQUAL( test_value, 7500 ) ;
+    test_value = (*clipped_values_one)(2);
+    BOOST_CHECK_EQUAL( test_value, 8500 ) ;
+    delete clipped_values_one;
+
+    // Min clip
+    seq_vector* clipped_values_two = values.clip(7000.0, 11000.0);
+
+    BOOST_CHECK_EQUAL( clipped_values_two->size(), 3 ) ;
+
+    test_value = (*clipped_values_two)(0);
+    BOOST_CHECK_EQUAL( test_value, 7500 ) ;
+    test_value = (*clipped_values_two)(1);
+    BOOST_CHECK_EQUAL( test_value, 8500 ) ;
+    test_value = (*clipped_values_two)(2);
+    BOOST_CHECK_EQUAL( test_value, 9500 ) ;
+    delete clipped_values_two;
+
+
+    // Max and Min clip
+    seq_vector* clipped_values_three = values.clip(7000.0, 9000.0);
+
+    BOOST_CHECK_EQUAL( clipped_values_three->size(), 2 ) ;
+
+    test_value = (*clipped_values_three)(0);
+    BOOST_CHECK_EQUAL( test_value, 7500 ) ;
+    test_value = (*clipped_values_three)(1);
+    BOOST_CHECK_EQUAL( test_value, 8500 ) ;
+    delete clipped_values_three;
+}
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/waveq3d/test/reflection_test.cc
+++ b/waveq3d/test/reflection_test.cc
@@ -34,8 +34,8 @@ public:
     double latitude ;
     bool surface ;
     bool bottom ;
-    int surf_count ;
-    int bot_count ;
+    size_t surf_count ;
+    size_t bot_count;
 
     /**
      * Initialize counter.
@@ -46,7 +46,7 @@ public:
 
     virtual ~reflection_callback() {}
 
-    bool check_count( int& old_count ) {
+    bool check_count( size_t& old_count ) {
         bottom = surface = false ;
         if( surf_count != _collection->eigenverbs(1).size() ) {
             surf_count = _collection->eigenverbs(1).size() ;
@@ -149,7 +149,7 @@ BOOST_AUTO_TEST_CASE( reflect_flat_test ) {
         eigenverb_collection verb_collection( 0 ) ;
         wave.add_eigenverb_listener( &verb_collection ) ;
         reflection_callback callback( &verb_collection ) ;
-        int old_count = callback.surf_count + callback.bot_count ;
+        size_t old_count = callback.surf_count + callback.bot_count ;
         double max_time_error = 0.0 ;
         double max_lat_error = 0.0 ;
 
@@ -214,7 +214,7 @@ BOOST_AUTO_TEST_CASE( reflect_flat_test ) {
             if( callback.check_count( old_count ) ) {
                 double predict_time = old_count * 7.450560973 ;
                 double current_time = callback.time ;
-                double predict_lat = 45.0 + old_count * 0.1 ;
+                double predict_lat = 45.0 + int(old_count) * 0.1 ;
                 double current_lat = callback.latitude ;
 
                 if ( callback.surface ) cout << "surface" ;

--- a/waveq3d/test/reflection_test.cc
+++ b/waveq3d/test/reflection_test.cc
@@ -41,7 +41,7 @@ public:
      * Initialize counter.
      */
     reflection_callback( eigenverb_collection* collection )
-        : _collection(collection), time(0.0), surf_count(0), bot_count(0)
+        : _collection(collection), time(0.0), latitude(0.0),  surf_count(0), bot_count(0)
     {}
 
     virtual ~reflection_callback() {}


### PR DESCRIPTION
Added seq_linear frequencies property to sensor_model manipulated by min/max active frequencies.
Added beam_list to source_params.
Changed sensor_pair to hold fathometer_model vs eigenrays.
Added  std::vector frequencies property to sensor_pair based on the intersection of receiver frequencies and source frequencies.
Added to sensor_manager_test to verify changes.