### PR TITLE
Modifed eigenray_listener and wave_queue to use the same design pattern

### DIFF
--- a/eigenverb/eigenverb_collection.h
+++ b/eigenverb/eigenverb_collection.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <usml/eigenverb/eigenverb.h>
+#include <usml/eigenverb/eigenverb_listener.h>
 //#include <usml/types/quadtree.h>
 
 using namespace usml::types;
@@ -27,7 +28,7 @@ namespace eigenverb {
  *    - Subsequent columns provide the upper and lower
  *    	interfaces for additional volume scattering layers.
  */
-class USML_DECLSPEC eigenverb_collection {
+class USML_DECLSPEC eigenverb_collection : public eigenverb_listener {
 
 public:
 

--- a/eigenverb/eigenverb_listener.h
+++ b/eigenverb/eigenverb_listener.h
@@ -1,0 +1,64 @@
+/*
+ * @file eigenverb_listener.h
+ * Abstract interface for alerting listeners to the
+ * results of a reverberation eigenverb calculation.
+ */
+#pragma once
+
+#include <usml/eigenverb/eigenverb.h>
+#include <usml/threads/smart_ptr.h>
+
+namespace usml {
+namespace eigenverb {
+
+using namespace usml::threads;
+
+/// @ingroup eigenverb
+/// @{
+
+/**
+ * Abstract interface for alerting listeners to the results of
+ * a reverberation eigenverb calculation.
+ */
+class USML_DECLSPEC eigenverb_listener {
+public:
+
+	/**
+	 * Destructor.
+	 */
+	virtual ~eigenverb_listener() {
+	}
+
+	/**
+	 * Pure virtual method to add an eigenverb for the object that implements it.
+	 *  @param  eigenverb - eigenverb data to add to list of eigenverbs
+	 *  @param  interface - Interface number for the interface that generated
+     *                      for this eigenverb.  See the eigenverb_collection
+     *                      class header for documentation on interpreting
+     *                      this number. For some layers, you can also use the
+     *                      eigenverb::interface_type.
+	 */
+	virtual void add_eigenverb(const eigenverb& verb, size_t interface) = 0;
+
+protected:
+
+	/**
+	 * Constructor - protected
+	 */
+	eigenverb_listener() {
+	}
+private:
+
+    // -------------------------
+    // Disabling default copy constructor and default
+    // assignment operator.
+    // -------------------------
+    eigenverb_listener(const eigenverb_listener& yRef);
+    eigenverb_listener& operator=(const eigenverb_listener& yRef);
+
+};
+
+/// @}
+} // end of namespace eigenverb
+} // end of namespace usml
+

--- a/eigenverb/eigenverb_notifier.cc
+++ b/eigenverb/eigenverb_notifier.cc
@@ -1,0 +1,32 @@
+/**
+ * @file eigenverb_notifier.cc
+ * Manage eigenverb listeners and distribute eigenverb updates.
+ */
+#include <usml/eigenverb/eigenverb_notifier.h>
+#include <boost/foreach.hpp>
+
+using namespace usml::eigenverb;
+
+/**
+ * Add an eigenverb listener to this object.
+ */
+void eigenverb_notifier::add_eigenverb_listener(eigenverb_listener* listener) {
+	_listeners.insert(listener) ;
+}
+
+/**
+ * Remove an eigenverb listener to this object.
+ */
+void eigenverb_notifier::remove_eigenverb_listener(eigenverb_listener* listener) {
+	_listeners.erase(listener) ;
+}
+
+/**
+ * Distribute an eigenverb updates to all listeners.
+ */
+void eigenverb_notifier::notify_eigenverb_listeners( const eigenverb& verb, size_t interface ) {
+	BOOST_FOREACH( eigenverb_listener* listener, _listeners ) {
+		listener->add_eigenverb(verb, interface) ;
+	}
+}
+

--- a/eigenverb/eigenverb_notifier.h
+++ b/eigenverb/eigenverb_notifier.h
@@ -1,0 +1,59 @@
+/*
+ * @file eigenverb_notifier.h
+ * Manage eigenverb listeners and distribute eigenverb updates.
+ */
+#pragma once
+
+#include <usml/eigenverb/eigenverb_listener.h>
+#include <set>
+
+namespace usml {
+namespace eigenverb {
+
+/// @ingroup eigenverb
+/// @{
+
+/**
+ * Manage eigenverb listeners and distribute eigenverb updates.
+ */
+class USML_DECLSPEC eigenverb_notifier {
+public:
+
+    /**
+     * Add an eigenverb listener to this object.
+     */
+    void add_eigenverb_listener(eigenverb_listener* listener) ;
+
+    /**
+     * Remove an eigenverb listener to this object.
+     */
+    void remove_eigenverb_listener(eigenverb_listener* listener) ;
+
+    /**
+     * Distribute an eigenverb updates to all listeners.
+     */
+    void notify_eigenverb_listeners( const eigenverb& verb, size_t interface) ;
+
+    /**
+     * Determines if any listeners exist
+     * @return true when listeners exist, false otherwise.
+     */
+    inline bool has_eigenverb_listeners() {
+        if (_listeners.size() > 0) {
+            return true;
+        }
+        return false;
+    }
+
+private:
+
+    /**
+     * List of active eigenverb listeners.
+     */
+    std::set<eigenverb_listener*> _listeners ;
+};
+
+/// @}
+} // end of namespace eigenverb
+} // end of namespace usml
+

--- a/eigenverb/envelope_listener.h
+++ b/eigenverb/envelope_listener.h
@@ -44,6 +44,15 @@ protected:
 	envelope_listener() {
 	}
 
+private:
+
+	// -------------------------
+    // Disabling default copy constructor and default
+    // assignment operator.
+    // -------------------------
+    envelope_listener(const envelope_listener& yRef);
+    envelope_listener& operator=(const envelope_listener& yRef);
+
 };
 
 /// @}

--- a/eigenverb/wavefront_generator.h
+++ b/eigenverb/wavefront_generator.h
@@ -13,7 +13,7 @@
 #include <usml/ocean/ocean_shared.h>
 #include <usml/waveq3d/eigenray_collection.h>
 #include <usml/waveq3d/wave_queue.h>
-#include <usml/waveq3d/eigenray_listener.h>
+#include <usml/waveq3d/eigenray_notifier.h>
 #include <usml/eigenverb/wavefront_listener.h>
 
 namespace usml {

--- a/studies/cmp_speed/cmp_speed.cc
+++ b/studies/cmp_speed/cmp_speed.cc
@@ -116,10 +116,7 @@ int main( int argc, char* argv[] ) {
     eigenray_collection loss(freq, src_pos, de, az, time_step, &target);
     wave_queue wave( ocean, freq, src_pos, de, az, time_step, &target ) ;
 
-    if (!wave.add_eigenray_listener(&loss)) {
-    	cout << "Error adding eigenray_collection listener! " << endl ;
-    	exit(1);
-    }
+    wave.add_eigenray_listener(&loss);
 
     // propagate wavefront
 

--- a/studies/eigenray_extra/eigenray_extra_test.cc
+++ b/studies/eigenray_extra/eigenray_extra_test.cc
@@ -177,14 +177,11 @@ BOOST_AUTO_TEST_CASE( eigenray_lloyds ) {
 
 	wave_queue wave( ocean, freq, pos, de, az, time_step, &target ) ;
 
-	if (!wave.add_eigenray_listener(&loss1)) {
-		cout << "Error adding eigenray_collection listener 1 ! " << endl ;
-		exit(1);
-	}
-	if (!wave.add_eigenray_listener(&loss2)) {
-		cout << "Error adding eigenray_collection listener 2! " << endl ;
-		exit(1);
-	}
+	// adding eigenray_collection listener 1
+	wave.add_eigenray_listener(&loss1);
+
+    //adding eigenray_collection listener 2
+	wave.add_eigenray_listener(&loss2);
 
     // propagate rays & record to log files
 

--- a/studies/pedersen/pedersen_test.cc
+++ b/studies/pedersen/pedersen_test.cc
@@ -297,10 +297,8 @@ void analyze_proploss(
 
     wave_queue wave( *ocean, freq, pos, de, az, time_inc, &target ) ;
 
-    if (!wave.add_eigenray_listener(&loss)) {
-    	cout << "Error adding eigenray_collection listener! " << endl ;
-    	exit(1);
-    }
+    // adding eigenray_collection listener
+    wave.add_eigenray_listener(&loss);
 
     // compute the eigenray_collection and store eigenrays to disk
 

--- a/waveq3d/eigenray_collection.cc
+++ b/waveq3d/eigenray_collection.cc
@@ -202,13 +202,11 @@ void eigenray_collection::sum_eigenrays( bool coherent ) {
 }
 
 /**
- * Add eigenray via proplossListener
+ * Add eigenray via eigenray_listener
  */
-bool eigenray_collection::add_eigenray( size_t targetRow, size_t targetCol, eigenray pRay, size_t run_id ) {
-
-	 _eigenrays(targetRow, targetCol).push_back( pRay ) ;
+void eigenray_collection::add_eigenray( size_t target_row, size_t target_col, eigenray ray ) {
+	 _eigenrays(target_row, target_col).push_back( ray ) ;
 	 ++_num_eigenrays ;
-	 return true;
 }
 
 /**

--- a/waveq3d/eigenray_collection.cc
+++ b/waveq3d/eigenray_collection.cc
@@ -204,7 +204,9 @@ void eigenray_collection::sum_eigenrays( bool coherent ) {
 /**
  * Add eigenray via eigenray_listener
  */
-void eigenray_collection::add_eigenray( size_t target_row, size_t target_col, eigenray ray ) {
+void eigenray_collection::add_eigenray(
+		size_t target_row, size_t target_col, eigenray ray, size_t runID )
+{
 	 _eigenrays(target_row, target_col).push_back( ray ) ;
 	 ++_num_eigenrays ;
 }

--- a/waveq3d/eigenray_collection.h
+++ b/waveq3d/eigenray_collection.h
@@ -28,9 +28,7 @@ class USML_DECLSPEC eigenray_collection : public eigenray_listener {
 public:
 
 	// eigenray_collection shared_ptr
-	typedef boost::shared_ptr<eigenray_collection> reference;
-
-	//typedef boost::shared_ptr<eigenray_list>  reference ;
+	typedef boost::shared_ptr<eigenray_collection> reference ;
 
 private:
 
@@ -198,14 +196,12 @@ public:
 	/**
 	 * add_eigenray - Adds an eigenray to the eigenray_list for the target specified.
 	 * implementation of the pure virtual method of proplossListener.
-	 * @param   targetRow          Row number of the current target.
-	 * @param   targetCol          Column number of the current target.
-	 * @param   pRay               The eigenray to add.
-	 * @param   run_id             The run_id of WaveQ3D which the eigenray was produced.
+	 * @param   target_row         Row number of the current target.
+	 * @param   target_col         Column number of the current target.
+	 * @param   ray                The eigenray to add.
 	 * @return                     True on success, false on failure.
 	 */
-	bool add_eigenray(size_t targetRow, size_t targetCol, eigenray pRay, size_t run_id );
-
+	void add_eigenray(size_t target_row, size_t target_col, eigenray ray) ;
 
     /**
      * Compute propagation loss summed over all eigenrays.

--- a/waveq3d/eigenray_collection.h
+++ b/waveq3d/eigenray_collection.h
@@ -194,14 +194,16 @@ public:
     }
 
 	/**
-	 * add_eigenray - Adds an eigenray to the eigenray_list for the target specified.
-	 * implementation of the pure virtual method of proplossListener.
-	 * @param   target_row         Row number of the current target.
-	 * @param   target_col         Column number of the current target.
-	 * @param   ray                The eigenray to add.
-	 * @return                     True on success, false on failure.
+	 * Adds a new eigenray to this collection for a specific target.
+	 * Implementation of the pure virtual method in eigenray_listener.
+	 *
+	 * @param   target_row 	Row identifier for the target involved in this collision.
+	 * @param   target_col 	Column identifier for the target involved in this collision.
+	 * @param   ray        	Propagation loss information for this collision.
+	 * @param 	runID		Identification number of the wavefront that
+	 * 						produced this result.  Ignored in this implementation.
 	 */
-	void add_eigenray(size_t target_row, size_t target_col, eigenray ray) ;
+	void add_eigenray(size_t target_row, size_t target_col, eigenray ray, size_t runID) ;
 
     /**
      * Compute propagation loss summed over all eigenrays.

--- a/waveq3d/eigenray_listener.h
+++ b/waveq3d/eigenray_listener.h
@@ -1,10 +1,7 @@
-/*
+/**
  * @file eigenray_listener.h
- *
- *  Created on: Sep 9, 2013
- *      Author: Ted Burns, AEgis Technologies Group, Inc.
+ * Abstract interface for passing newly created eigenrays to an observer.
  */
-
 #pragma once
 
 #include <usml/waveq3d/eigenray.h>
@@ -16,12 +13,11 @@ namespace waveq3d {
 /// @{
 
 /**
- * @class eigenray_listener
- * @brief This class is part of a Observer/Subject pattern for the wave_queue class
- * and allows for multiple eigenray listeners to be added to wave_queue.
- * The add_eigenray call must be defined in each class which inherits it.
+ * Abstract interface for passing newly created eigenrays to an observer.
+ * Uses an Observer/Subject pattern which allows the receiver to process
+ * propagation information as soon as it becomes available. The observer does
+ * not need to wait until the propagation model is complete.
  */
-
 class USML_DECLSPEC eigenray_listener {
 public:
 
@@ -33,25 +29,31 @@ public:
 	}
 
 	/**
-	 * Pure virtual method to add eigenray to an object.
-	 *  @param   target_row Index of the target row to add to list of eigenrays
-     *  @param   target_col Index of the target row to add to list of eigenrays
-     *  @param   ray        eigenray data to add to list of eigenrays
-     *  @param   run_id     Run Identification number.
+	 * Notifies the observer that a wave front collision has been detected for
+	 * one of the targets. Targets are specified by a row and column number.
+	 * Must be overloaded by sub-classes.
+	 *
+	 * @param   target_row 	Row identifier for the target involved in this collision.
+	 * @param   target_col 	Column identifier for the target involved in this collision.
+	 * @param   ray        	Propagation loss information for this collision.
+	 * @param 	runID		Identification number of the wavefront that
+	 * 						produced this result.
+	 * @see		wave_queue.runID()
 	 */
-	virtual void add_eigenray(size_t target_row, size_t target_col, eigenray ray) = 0; //, size_t run_id) = 0;
-	
-	/**
-	 * Virtual method to check if all eigenrays are available within a time frame.
-	 *  @param 	run_id      Run number of waveQ3D
-	 *  @param  wave_time   Current Time of the wavefront used to check elapsed time.
-	 *  @return  		    True on Success, false otherwise.
-	 */
-	virtual bool check_eigenrays(size_t runID, long wave_time)
-	{
-		return false;
-	}
+	virtual void add_eigenray(
+		size_t target_row, size_t target_col, eigenray ray, size_t runID) = 0;
 
+	/**
+	 * Notifies the observer that eigenray processing is complete for
+	 * a specific wavefront time step. This can be used to limit the time
+	 * window for eigenrays to each specific target.
+	 *
+	 * @param  wave_time   	Elapsed time for this wavefront step.
+	 * @param 	runID		Identification number of the wavefront that
+	 * 						produced this result.
+	 * @see		wave_queue.runID()
+	 */
+	virtual void check_eigenrays(long wave_time, size_t runID) {}
 
 protected:
 
@@ -60,20 +62,19 @@ protected:
 	 */
 	eigenray_listener() {}
 
-
-
 private:
 
-	// -------------------------
-	// Disabling default copy constructor and default
-	// assignment operator.
-	// -------------------------
+	/*
+	 * Disabling default copy constructor and default
+	 * assignment operator.
+	  */
 	eigenray_listener(const eigenray_listener& yRef);
 	eigenray_listener& operator=(const eigenray_listener& yRef);
 
 };
 
 /// @}
-} // end of namespace waveq3d
-} // end of namespace usml
+}
+	// end of namespace waveq3d
+}	// end of namespace usml
 

--- a/waveq3d/eigenray_listener.h
+++ b/waveq3d/eigenray_listener.h
@@ -22,31 +22,32 @@ namespace waveq3d {
  * The add_eigenray call must be defined in each class which inherits it.
  */
 
-class USML_DECLSPEC eigenray_listener
-{
+class USML_DECLSPEC eigenray_listener {
 public:
 
 	/**
 	 * Destructor.
 	 */
-	virtual ~eigenray_listener() {}
+	virtual ~eigenray_listener() {
+
+	}
 
 	/**
 	 * Pure virtual method to add eigenray to an object.
-	 *  @param   targetRow Index of the target row to add to list of eigenrays
-     *  @param   targetCol Index of the target row to add to list of eigenrays
-     *  @param   pRay      Pointer to eigenray data to add to list of eigenrays
-     *  @param   run_id    Run Identification number.
+	 *  @param   target_row Index of the target row to add to list of eigenrays
+     *  @param   target_col Index of the target row to add to list of eigenrays
+     *  @param   ray        eigenray data to add to list of eigenrays
+     *  @param   run_id     Run Identification number.
 	 */
-	virtual bool add_eigenray(size_t targetRow, size_t targetCol, eigenray pRay, size_t run_id) = 0;
+	virtual void add_eigenray(size_t target_row, size_t target_col, eigenray ray) = 0; //, size_t run_id) = 0;
 	
 	/**
 	 * Virtual method to check if all eigenrays are available within a time frame.
-	 *  @param 	runID Run number of waveQ3D
-	 *  @param  waveTime Current Time of the wavefront used to check elapsed time.
-	 *  @return  		   True on Success, false otherwise.
+	 *  @param 	run_id      Run number of waveQ3D
+	 *  @param  wave_time   Current Time of the wavefront used to check elapsed time.
+	 *  @return  		    True on Success, false otherwise.
 	 */
-	virtual bool check_eigenrays(size_t runID, long waveTime)
+	virtual bool check_eigenrays(size_t runID, long wave_time)
 	{
 		return false;
 	}

--- a/waveq3d/eigenray_notifier.cc
+++ b/waveq3d/eigenray_notifier.cc
@@ -11,22 +11,24 @@ using namespace usml::waveq3d;
  * Add an eigenray listener to this object.
  */
 void eigenray_notifier::add_eigenray_listener(eigenray_listener* listener) {
-	_listeners.insert(listener) ;
+	_listeners.insert(listener);
 }
 
 /**
  * Remove an eigenray listener to this object.
  */
 void eigenray_notifier::remove_eigenray_listener(eigenray_listener* listener) {
-	_listeners.erase(listener) ;
+	_listeners.erase(listener);
 }
 
 /**
  * Distribute an eigenray updates to all listeners.
  */
-void eigenray_notifier::notify_eigenray_listeners( size_t target_row, size_t target_col, eigenray ray ) {
-	BOOST_FOREACH( eigenray_listener* listener, _listeners ) {
-		 listener->add_eigenray(target_row, target_col, ray) ;
+void eigenray_notifier::notify_eigenray_listeners(
+		size_t target_row, size_t target_col, eigenray ray, size_t runID)
+{
+	BOOST_FOREACH( eigenray_listener* listener, _listeners ){
+		listener->add_eigenray(target_row, target_col, ray, runID);
 	}
 }
 
@@ -35,9 +37,9 @@ void eigenray_notifier::notify_eigenray_listeners( size_t target_row, size_t tar
  * call the check_eigenrays method to deliver all eigenrays after
  * a certain amount of time has passed.
  */
-void eigenray_notifier::check_eigenray_listeners(size_t run_id, long wave_time) {
-    BOOST_FOREACH( eigenray_listener* listener, _listeners ) {
-         listener->check_eigenrays(run_id, wave_time);
-    }
+void eigenray_notifier::check_eigenray_listeners(long wave_time, size_t runID) {
+	BOOST_FOREACH( eigenray_listener* listener, _listeners ){
+		listener->check_eigenrays(wave_time, runID);
+	}
 }
 

--- a/waveq3d/eigenray_notifier.cc
+++ b/waveq3d/eigenray_notifier.cc
@@ -1,0 +1,43 @@
+/**
+ * @file eigenray_notifier.cc
+ * Manage eigenray listeners and distribute eigenray updates.
+ */
+#include <usml/waveq3d/eigenray_notifier.h>
+#include <boost/foreach.hpp>
+
+using namespace usml::waveq3d;
+
+/**
+ * Add an eigenray listener to this object.
+ */
+void eigenray_notifier::add_eigenray_listener(eigenray_listener* listener) {
+	_listeners.insert(listener) ;
+}
+
+/**
+ * Remove an eigenray listener to this object.
+ */
+void eigenray_notifier::remove_eigenray_listener(eigenray_listener* listener) {
+	_listeners.erase(listener) ;
+}
+
+/**
+ * Distribute an eigenray updates to all listeners.
+ */
+void eigenray_notifier::notify_eigenray_listeners( size_t target_row, size_t target_col, eigenray ray ) {
+	BOOST_FOREACH( eigenray_listener* listener, _listeners ) {
+		 listener->add_eigenray(target_row, target_col, ray) ;
+	}
+}
+
+/**
+ * For each eigenray_listener in the eigenray_listeners set
+ * call the check_eigenrays method to deliver all eigenrays after
+ * a certain amount of time has passed.
+ */
+void eigenray_notifier::check_eigenray_listeners(size_t run_id, long wave_time) {
+    BOOST_FOREACH( eigenray_listener* listener, _listeners ) {
+         listener->check_eigenrays(run_id, wave_time);
+    }
+}
+

--- a/waveq3d/eigenray_notifier.h
+++ b/waveq3d/eigenray_notifier.h
@@ -19,47 +19,64 @@ namespace waveq3d {
 class USML_DECLSPEC eigenray_notifier {
 
 public:
-    /**
-     * Add an eigenray listener to this object.
-     */
-    void add_eigenray_listener(eigenray_listener* listener) ;
 
-    /**
-     * Remove an eigenray listener to this object.
-     */
-    void remove_eigenray_listener(eigenray_listener* listener) ;
+	/**
+	 * Add an eigenray listener to this object.
+	 */
+	void add_eigenray_listener(eigenray_listener* listener);
 
-    /**
-     * Distribute eigenray updates to all listeners.
-     */
-    void notify_eigenray_listeners( size_t target_row, size_t target_col, eigenray ray) ;
-    /**
-     * For each eigenray_listener in the eigenray_listeners set
-     * call the check_eigenrays method to deliver all eigenrays after
-     * a certain amount of time has passed.
-     */
-    void check_eigenray_listeners(size_t run_id, long wave_time ) ;
+	/**
+	 * Remove an eigenray listener to this object.
+	 */
+	void remove_eigenray_listener(eigenray_listener* listener);
 
-    /**
-     * Determines if any listeners exist
-     * @return true when listeners exist, false otherwise.
-     */
-    inline bool has_eigenray_listeners() {
-        if (_listeners.size() > 0) {
-            return true;
-        }
-        return false;
-    }
+	/**
+	 * Notifies all of the listeners that a wave front collision has been detected for
+	 * one of the targets. Targets are specified by a row and column number.
+	 *
+	 * @param   target_row 	Row identifier for the target involved in this collision.
+	 * @param   target_col 	Column identifier for the target involved in this collision.
+	 * @param   ray        	Propagation loss information for this collision.
+	 * @param 	runID		Identification number of the wavefront that
+	 * 						produced this result.
+	 * @see		wave_queue.runID()
+	 */
+	void notify_eigenray_listeners(
+			size_t target_row, size_t target_col, eigenray ray, size_t runID );
+
+	/**
+	 * Notifies all of the listeners that eigenray processing is complete for
+	 * a specific wavefront time step. This can be used to limit the time
+	 * window for eigenrays to each specific target.
+	 *
+	 * @param  wave_time   	Elapsed time for this wavefront step.
+	 * @param 	runID		Identification number of the wavefront that
+	 * 						produced this result.
+	 * @see		wave_queue.runID()
+	 */
+	void check_eigenray_listeners( long wave_time, size_t runID );
+
+	/**
+	 * Determines if any listeners exist
+	 * @return true when listeners exist, false otherwise.
+	 */
+	inline bool has_eigenray_listeners() {
+		if (_listeners.size() > 0) {
+			return true;
+		}
+		return false;
+	}
 
 private:
 
-    /**
-     * List of active eigenray listeners.
-     */
-    std::set<eigenray_listener*> _listeners ;
+	/**
+	 * List of active eigenray listeners.
+	 */
+	std::set<eigenray_listener*> _listeners;
 };
 
 /// @}
-} // end of namespace waveq3d
-} // end of namespace usml
+}
+ // end of namespace waveq3d
+}// end of namespace usml
 

--- a/waveq3d/eigenray_notifier.h
+++ b/waveq3d/eigenray_notifier.h
@@ -1,0 +1,65 @@
+/*
+ * @file eigenray_notifier.h
+ * Manage eigenray listeners and distribute eigenray updates.
+ */
+#pragma once
+
+#include <usml/waveq3d/eigenray_listener.h>
+#include <set>
+
+namespace usml {
+namespace waveq3d {
+
+/// @ingroup waveq3d
+/// @{
+
+/**
+ * Manage eigenray listeners and distribute eigenray updates.
+ */
+class USML_DECLSPEC eigenray_notifier {
+
+public:
+    /**
+     * Add an eigenray listener to this object.
+     */
+    void add_eigenray_listener(eigenray_listener* listener) ;
+
+    /**
+     * Remove an eigenray listener to this object.
+     */
+    void remove_eigenray_listener(eigenray_listener* listener) ;
+
+    /**
+     * Distribute eigenray updates to all listeners.
+     */
+    void notify_eigenray_listeners( size_t target_row, size_t target_col, eigenray ray) ;
+    /**
+     * For each eigenray_listener in the eigenray_listeners set
+     * call the check_eigenrays method to deliver all eigenrays after
+     * a certain amount of time has passed.
+     */
+    void check_eigenray_listeners(size_t run_id, long wave_time ) ;
+
+    /**
+     * Determines if any listeners exist
+     * @return true when listeners exist, false otherwise.
+     */
+    inline bool has_eigenray_listeners() {
+        if (_listeners.size() > 0) {
+            return true;
+        }
+        return false;
+    }
+
+private:
+
+    /**
+     * List of active eigenray listeners.
+     */
+    std::set<eigenray_listener*> _listeners ;
+};
+
+/// @}
+} // end of namespace waveq3d
+} // end of namespace usml
+

--- a/waveq3d/reflection_model.cc
+++ b/waveq3d/reflection_model.cc
@@ -99,7 +99,7 @@ bool reflection_model::bottom_reflection( size_t de, size_t az, double depth ) {
 
     // invoke bottom reverberation callback
 
-    if ( _wave._collection ) {
+    if ( _wave.has_eigenverb_listeners() ) {
 		_wave.build_eigenverb( de, az, time_water, grazing, c,
 			position, ndirection, usml::eigenverb::eigenverb::BOTTOM ) ;
     }
@@ -164,7 +164,7 @@ bool reflection_model::surface_reflection( size_t de, size_t az ) {
     if ( grazing <= 0.0 ) return false ;	// near miss of the surface
 
     // surface reverberation callback
-    if ( _wave._collection ) {
+    if ( _wave.has_eigenverb_listeners() ) {
 		_wave.build_eigenverb( de, az, time_water, grazing, c,
 			position, ndirection, usml::eigenverb::eigenverb::SURFACE ) ;
     }

--- a/waveq3d/wave_queue.cc
+++ b/waveq3d/wave_queue.cc
@@ -45,7 +45,6 @@ wave_queue::wave_queue(
     _time( 0.0 ),
     _targets( targets ),
     _run_id(run_id),
-	_collection( NULL ),
     _nc_file( NULL )
 {
     _az_boundary = false ;
@@ -108,16 +107,6 @@ wave_queue::~wave_queue() {
     delete _prev ;
     delete _curr ;
     delete _next ;
-}
-
-/**
- * Assigns an eigeverb_collection to the reflection model
- */
-void wave_queue::add_eigenverb_listener(
-    eigenverb_collection* collection )
-{
-    if( _collection ) delete _collection ;
-    _collection = collection ;
 }
 
 /**
@@ -300,7 +289,7 @@ void wave_queue::detect_caustics( size_t de, size_t az ) {
  * Detect volume boundary reflections for reverberation contributions
  */
 void wave_queue::detect_volume_scattering(size_t de, size_t az) {
-	if ( _collection == NULL ) return;
+	if ( !has_eigenverb_listeners() ) return;
 	std::size_t n = _ocean.num_volume();
 	for (std::size_t i = 0; i < n; ++i) {
 		volume_model& layer = _ocean.volume(i);
@@ -1030,7 +1019,7 @@ void wave_queue::build_eigenverb(
     double speed, const wposition1& position,
     const wvector1& ndirection, size_t type )
 {
-	if ( _collection == NULL ) return ;
+	if ( !has_eigenverb_listeners() ) return;
 	grazing = abs(grazing) ;
 	if ( _time <= 0.0 || grazing < 1e-6 ) return ;
 	if ( this->_az_boundary && az == this->_max_az ) return;
@@ -1112,65 +1101,7 @@ void wave_queue::build_eigenverb(
 			<< "\tsurface="	<< verb.surface << " bottom=" << verb.bottom
 			<< " caustic=" << verb.caustic << endl;
 	#endif
-	_collection->add_eigenverb( verb, type ) ;
+
+	notify_eigenverb_listeners(verb, type) ;
 //	cout << "wave_queue::build_eigenverb() - done " << endl ;
-}
-
-/**
-* Add a eigenray_listener to the eigenray_listeners vector
-*/
-bool wave_queue::add_eigenray_listener(eigenray_listener* pListener) {
-
-    std::vector<eigenray_listener*>::iterator iter = find(eigenray_listeners.begin(), eigenray_listeners.end(), pListener);
-    if ( iter != eigenray_listeners.end() ) {
-        return false;
-    }
-    eigenray_listeners.push_back(pListener);
-    return true;
-}
-
-
-/**
- * Remove a eigenray_listener from the eigenray_listeners vector
- */
-bool wave_queue::remove_eigenray_listener(eigenray_listener* pListener){
-
-    std::vector<eigenray_listener*>::iterator iter = find(eigenray_listeners.begin(), eigenray_listeners.end(), pListener);
-    if ( iter == eigenray_listeners.end() ){
-        return false;
-    } else {
-        eigenray_listeners.erase(remove(eigenray_listeners.begin(), eigenray_listeners.end(), pListener));
-    }
-    return true;
-}
-
-/**
- * For each eigenray_listener in the eigenray_listeners vector
- * call the add_eigenray method to provide eigenrays.
- */
-bool wave_queue::notify_eigenray_listeners(size_t targetRow, size_t targetCol, eigenray pEigenray){
-
-    for (std::vector<eigenray_listener*>::iterator iter = eigenray_listeners.begin();
-                                                iter != eigenray_listeners.end(); ++iter){
-        eigenray_listener* pListener = *iter;
-        pListener->add_eigenray(targetRow, targetCol, pEigenray, _run_id);
-    }
-
-    return (eigenray_listeners.size() > 0);
-}
-
-/**
- * For each eigenray_listener in the eigenray_listeners vector
- * call the check_eigenrays method to deliver all eigenrays after
- * a certain amount of time has passed.
- */
-bool wave_queue::check_eigenray_listeners(long waveTime){
-
-    for (std::vector<eigenray_listener*>::iterator iter = eigenray_listeners.begin();
-                                                iter != eigenray_listeners.end(); ++iter){
-        eigenray_listener* pListener = *iter;
-        pListener->check_eigenrays((unsigned long)_run_id, waveTime);
-    }
-
-    return (eigenray_listeners.size() > 0);
 }

--- a/waveq3d/wave_queue.cc
+++ b/waveq3d/wave_queue.cc
@@ -189,6 +189,10 @@ void wave_queue::step() {
     // search for eigenray collisions with acoustic targets
 
     detect_eigenrays() ;
+
+    // notify listeners that this step is complete
+
+    check_eigenray_listeners( _time, runID() ) ;
 }
 
 /**
@@ -665,7 +669,7 @@ void wave_queue::build_eigenray(
              << "\tsurface=" << ray.surface << " bottom=" << ray.bottom << " caustic=" << ray.caustic << endl ;
     #endif
     // Add eigenray to those objects which requested them
-    notify_eigenray_listeners(t1,t2,ray);
+    notify_eigenray_listeners(t1,t2,ray,runID());
 
 }
 

--- a/waveq3d/wave_queue.h
+++ b/waveq3d/wave_queue.h
@@ -269,18 +269,21 @@ class USML_DECLSPEC wave_queue : public eigenray_notifier, public eigenverb_noti
 	}
 
     /**
-     * Set the id for the next run.
-     * @param run_id
+     * Optional identification number for this wavefront calculation.
+	 * This can be used to correlate results to a specific wavefront when
+	 * concurrent wavefronts are used.  The scheme for defining this ID
+	 * can be different for each sonar training system.
+	 *
+     * @param id	New identification number for this wavefront calculation.
      */
-    inline void ID( size_t id ) {
+    inline void runID( size_t id ) {
         _run_id = id ;
     }
 
     /**
-     * Get the run_id
-     * @return  current run id value
+     * Optional identification number for this wavefront calculation.
      */
-    inline const size_t ID() {
+    inline const size_t runID() {
         return _run_id ;
     }
 

--- a/waveq3d/wave_queue.h
+++ b/waveq3d/wave_queue.h
@@ -6,7 +6,8 @@
 
 #include <usml/ocean/ocean.h>
 #include <usml/waveq3d/wave_front.h>
-#include <usml/waveq3d/eigenray_listener.h>
+#include <usml/waveq3d/eigenray_notifier.h>
+#include <usml/eigenverb/eigenverb_notifier.h>
 #include <usml/eigenverb/eigenverb_collection.h>
 #include <netcdfcpp.h>
 
@@ -15,11 +16,11 @@ namespace waveq3d {
 
 using namespace usml::ocean ;
 using namespace usml::eigenverb ;
+
 class reflection_model ;
 class spreading_model ;
 class spreading_ray ;
 class spreading_hybrid_gaussian ;
-class eigenray_listener ;
 
 /// @ingroup waveq3d
 /// @{
@@ -59,7 +60,7 @@ class eigenray_listener ;
  * @xref S.M. Reilly, G. Potty, Sonar Propagation Modeling using Hybrid
  * Gaussian Beams in Spherical/Time Coordinates, January 2012.
  */
-class USML_DECLSPEC wave_queue {
+class USML_DECLSPEC wave_queue : public eigenray_notifier, public eigenverb_notifier {
 
     friend class reflection_model ;
     friend class spreading_ray ;
@@ -268,45 +269,16 @@ class USML_DECLSPEC wave_queue {
 	}
 
     /**
-     * Add a eigenray_listener to the eigenray_listeners vector
-     */
-    bool add_eigenray_listener(eigenray_listener* pListener);
-
-    /**
-	 * Remove a eigenray_listener from the eigenray_listeners vector
-	 */
-    bool remove_eigenray_listener(eigenray_listener* pListener);
-
-    /**
-	 * For each eigenray_listener in the eigenray_listeners vector
-	 * call the check_eigenrays method to deliver all eigenrays after
-	 * a certain amount of time has passed.
-	 *  @param	waveTime Current Time of the WaveFront in msec
-	 *  @return True on success, false on failure.
-	 */
-	bool check_eigenray_listeners(long waveTime);
-
-	/**
-	 * Adds an eigenverb_collection to the wave_queue to store
-	 * all important information regarding eigenverbs to be used
-	 * to compute reverberation envelope.
-	 */
-	void add_eigenverb_listener( eigenverb_collection* collection ) ;
-
-    /**
-     * Set the type of wavefront that this is, i.e. a wavefront
-     * originating from a source or receiver. This is exclusively
-     * used within the reverbation models.
+     * Set the id for the next run.
+     * @param run_id
      */
     inline void ID( size_t id ) {
         _run_id = id ;
     }
 
     /**
-     * Get the type of wavefront that this is, i.e. a wavefront
-     * originating from a source or receiver. This is exclusively
-     * used within the reverbation models.
-     * @return      Type of wavefront (receiver/source)
+     * Get the run_id
+     * @return  current run id value
      */
     inline const size_t ID() {
         return _run_id ;
@@ -434,15 +406,15 @@ class USML_DECLSPEC wave_queue {
     wave_front *_past, *_prev, *_curr, *_next ;
 
 
-    /**
-	* Vector containing the references of objects that will be used to
-	* update classes that require eigenrays as they are built.
-	* These classes must implement add_eigenray method.
-	*/
-    std::vector<eigenray_listener *> eigenray_listeners;
+//    /**
+//	* Vector containing the references of objects that will be used to
+//	* update classes that require eigenrays as they are built.
+//	* These classes must implement add_eigenray method.
+//	*/
+//    std::vector<eigenray_listener *> eigenray_listeners;
 
-    /** Associated eigenverb collection **/
-    eigenverb_collection* _collection ;
+//    /** Associated eigenverb collection **/
+//    eigenverb_collection* _collection ;
 
     /**
      * Create an Azimuthal boundary loop condition upon initialization.
@@ -745,12 +717,6 @@ class USML_DECLSPEC wave_queue {
         wposition1* position, wvector1* ndirection, double* speed ) const ;
 
     /**
-	 * For each eigenray_listener in the eigenray_listeners vector
-	 * call the add_eigenray method to provide eigenrays to object that requested them.
-	 */
-	bool notify_eigenray_listeners(size_t targetRow, size_t targetCol, eigenray pEigenray);
-
-    /**
      * Constructs an eigenverb from the data provided. If the eigenverb meets
      * the intensity threshold, the eigenverb is passed to the collision
      * listener who then calls its collector to save the eigenverb.
@@ -864,7 +830,7 @@ class USML_DECLSPEC wave_queue {
 
     /**
      * Write current record to netCDF wavefront log.
-     * Records travel time, latitude, longtiude, altitude for
+     * Records travel time, latitude, longitude, altitude for
      * the current wavefront.
      */
     void save_netcdf() ;


### PR DESCRIPTION
Resolves issue #143.
* Modifed eigenray_listener and wave_queue to use the same design pattern as envelope_listener and envelope_notifier.
* Modifed add_eigenverb_listener of wave_queue to use the same design pattern as envelope_listener and envelope_notifier. This removed the _collection item from wave_queue. A has_eigenverb_listener call was provided to check for no _collection. 
* The boolean return on add_eigenray_listener was removed, as this was not required, thus causing tests and studies to be updated not to check for failed listener addition. 
