### PR TITLE
Use sub-set of source eigenverb frequencies in envelope calculations.

### DIFF
--- a/eigenverb/envelope_collection.h
+++ b/eigenverb/envelope_collection.h
@@ -17,8 +17,8 @@ using namespace usml::types;
  * Computes and stores the reverberation envelope time series for all
  * combinations of receiver azimuth, source beam number, receiver beam number.
  * Relies on envelope_model to calculate the actual time series for each
- * transmit frequency.  Each envelope is stored as a matrix that represents
- * the results a function of the sensor_pair's transmit frequency (rows)
+ * envelope frequency.  Each envelope is stored as a matrix that represents
+ * the results a function of the sensor_pair's envelope frequency (rows)
  * and two-way travel time (columns).
  */
 class USML_DECLSPEC envelope_collection {
@@ -32,20 +32,25 @@ public:
 	 * Reserve memory in which to store results as a series of
 	 * nested dynamic arrays.
 	 *
-	 * @param transmit_freq	Frequencies at which the source and receiver
-	 * 						eigenverbs are computed (Hz).
-	 * @param num_times		Number of times in the reverberation time series.
-	 * @param time_step		Sampling period of the reverberation time series.
-	 * @param pulse_length	Duration of the transmitted pulse (sec).
-	 * 						Defines the temporal resolution of the envelope.
-	 * @param threshold		Minimum intensity level for valid reverberation
-	 * 						contributions (linear units).
-	 * @param num_azimuths	Number of receiver azimuths in result.
-	 * @param num_src_beams	Number of source beams in result.
-	 * @param num_rcv_beams Number of receiver beams in result.
+	 * @param envelope_freq		Frequencies at which the source and receiver
+	 * 							eigenverbs overlap (Hz).  Frequencies at which
+	 * 							envelope will be computed.
+	 * @param src_freq_first	Index of the first source frequency that
+	 * 							overlaps receiver (Hz).  Used to map
+	 * 							source eigenverbs onto envelope_freq values.
+	 * @param travel_time		Times at which the sensor_pair's
+	 * 							reverberation envelopes are computed (Hz).
+	 * @param pulse_length		Duration of the transmitted pulse (sec).
+	 * 							Defines the temporal resolution of the envelope.
+	 * @param threshold			Minimum intensity level for valid reverberation
+	 * 							contributions (linear units).
+	 * @param num_azimuths		Number of receiver azimuths in result.
+	 * @param num_src_beams		Number of source beams in result.
+	 * @param num_rcv_beams 	Number of receiver beams in result.
 	 */
 	envelope_collection(
-		const seq_vector* transmit_freq,
+		const seq_vector* envelope_freq,
+		size_t src_freq_first,
 		const seq_vector* travel_time,
 		double reverb_duration,
 		double pulse_length,
@@ -62,8 +67,8 @@ public:
 	/**
 	 * Frequencies at which the source and receiver eigenverbs are computed (Hz).
 	 */
-	const seq_vector* transmit_freq() const {
-		return _transmit_freq ;
+	const seq_vector* envelope_freq() const {
+		return _envelope_freq ;
 	}
 
 	/**
@@ -112,7 +117,7 @@ public:
 	 * @param src_beam	Source beam number.
 	 * @param rcv_beam	Receiver beam number
 	 * @return			Reverberation intensity at each point the time series.
-	 * 					Each row represents a specific transmit frequency.
+	 * 					Each row represents a specific envelope frequency.
 	 * 					Each column represents a specific travel time.
 	 */
 	const matrix< double >& envelope(
@@ -133,13 +138,13 @@ public:
 	 *
 	 * @param src_verb	Eigenverb contribution from the source.
 	 * @param rcv_verb	Eigenverb contribution from the receiver.
-	 * @param src_beam	Source beam level at each transmit frequency (ratio).
-	 * 					Each row represents a specific transmit frequency.
+	 * @param src_beam	Source beam level at each envelope frequency (ratio).
+	 * 					Each row represents a specific envelope frequency.
 	 * 					Each column represents a beam number.
-	 * @param rcv_beam	Receiver beam level at each transmit frequency (ratio).
-	 * 					Each row represents a specific transmit frequency.
+	 * @param rcv_beam	Receiver beam level at each envelope frequency (ratio).
+	 * 					Each row represents a specific envelope frequency.
 	 * 					Each column represents a beam number.
-	 * @param scatter	Scattering strength at each transmit frequency (ratio).
+	 * @param scatter	Scattering strength at each envelope frequency (ratio).
 	 * @param xs2		Square of the relative distance from the
 	 * 					receiver to the target along the direction
 	 * 					of the receiver's length.
@@ -160,9 +165,10 @@ public:
 private:
 
 	/**
-	 * Frequencies at which the source and receiver eigenverbs are computed (Hz).
+	 * Frequencies at which the source and receiver eigenverbs overlap (Hz).
+	 * Frequencies at which envelope will be computed.
 	 */
-	const seq_vector* _transmit_freq ;
+	const seq_vector* _envelope_freq ;
 
 	/**
 	 * Times at which the sensor_pair's reverberation envelopes
@@ -201,7 +207,7 @@ private:
 	 * The order of indices is azimuth number, source beam number,
 	 * and then receiver beam number.  Each envelope is stored as a
 	 * matrix that represents the results a function of the sensor_pair's
-	 * transmit frequency (rows) and two-way travel time (columns).
+	 * envelope frequency (rows) and two-way travel time (columns).
 	 */
 	matrix< double >**** _envelopes;
 };

--- a/eigenverb/envelope_generator.cc
+++ b/eigenverb/envelope_generator.cc
@@ -30,7 +30,8 @@ unique_ptr<const seq_vector> envelope_generator::_travel_time( new seq_linear(0.
  * this specific task.
  */
 envelope_generator::envelope_generator(
-		const seq_vector* transmit_freq,
+		const seq_vector* envelope_freq,
+		size_t src_freq_first,
 		const seq_vector* receiver_freq,
 		double reverb_duration,
 		double pulse_length,
@@ -44,11 +45,12 @@ envelope_generator::envelope_generator(
 	_ocean( ocean_shared::current() ),
 	_src_eigenverbs(src_eigenverbs),
 	_rcv_eigenverbs(rcv_eigenverbs),
-	_eigenverb_interpolator(transmit_freq,receiver_freq)
+	_eigenverb_interpolator(receiver_freq,envelope_freq)
 {
 	write_lock_guard guard(_property_mutex);
 	_envelopes = envelope_collection::reference( new envelope_collection(
-		transmit_freq,
+		envelope_freq,
+		src_freq_first,
 		_travel_time.get(),
 		reverb_duration,
 		pulse_length,
@@ -65,7 +67,7 @@ void envelope_generator::run() {
 
 	// create memory for work products
 
-    const seq_vector* freq = _envelopes->transmit_freq() ;
+    const seq_vector* freq = _envelopes->envelope_freq() ;
     size_t num_freq = freq->size() ;
     size_t num_src_beams = _envelopes->num_src_beams() ;
     size_t num_rcv_beams = _envelopes->num_rcv_beams() ;

--- a/eigenverb/envelope_generator.h
+++ b/eigenverb/envelope_generator.h
@@ -54,14 +54,22 @@ public:
 	/**
 	 * Initialize model parameters and reserve memory.
 	 *
-	 * @param transmit_freq	Frequencies at which the source and receiver
-	 * 						eigenverbs are computed (Hz).
+	 * @param envelope_freq		Frequencies at which the source and receiver
+	 * 							eigenverbs overlap (Hz).  Frequencies at which
+	 * 							envelope will be computed.
+	 * @param src_freq_first	Index of the first intersecting frequency of the
+	 * 							source frequencies seq_vector.  Used to map
+	 * 							source eigenverbs onto envelope_freq values.
+	 * @param receiver_freq		Frequencies at which receiver eigenverbs were
+	 * 							generated (Hz).  Used to interpolate receiver
+	 * 							eigenverbs onto envelope_freq values.
 	 * @param num_azimuths	Number of receiver azimuths in result.
 	 * @param num_src_beams	Number of source beams in result.
 	 * @param num_rcv_beams Number of receiver beams in result.
 	 */
 	envelope_generator(
-		const seq_vector* transmit_freq,
+		const seq_vector* envelope_freq,
+		size_t src_freq_first,
 		const seq_vector* receiver_freq,
 		double reverb_duration,
 		double pulse_length,

--- a/eigenverb/envelope_model.cc
+++ b/eigenverb/envelope_model.cc
@@ -174,11 +174,11 @@ bool envelope_model::compute_overlap(
     // compute the duration of the overlap
 
     det_sr = element_div( det_sr, src_prod * rcv_prod ) ;
-	src_sum = 1.0 / src_verb.width2 + 1.0 / src_verb.length2 ;
-	src_diff = 1.0 / src_verb.width2 - 1.0 / src_verb.length2 ;
+	src_sum = 1.0 / src_verb_width2 + 1.0 / src_verb_length2 ;
+	src_diff = 1.0 / src_verb_width2 - 1.0 / src_verb_length2 ;
 	noalias(_duration) = 0.5 * element_div(
-			( 1.0 / src_verb.width2 + 1.0 / src_verb.length2 )
-			+ ( 1.0 / src_verb.width2 - 1.0 / src_verb.length2 ) * cos2alpha
+			( 1.0 / src_verb_width2 + 1.0 / src_verb_length2 )
+			+ ( 1.0 / src_verb_width2 - 1.0 / src_verb_length2 ) * cos2alpha
 			+ 2.0 / rcv_verb.width2,
 			det_sr ) ;
 //    cout << "det_sr=" << det_sr

--- a/eigenverb/envelope_model.cc
+++ b/eigenverb/envelope_model.cc
@@ -17,17 +17,19 @@ using namespace usml::eigenverb;
  * Reserve the memory used to store the results of this calculation.
  */
 envelope_model::envelope_model(
-	const seq_vector* transmit_freq,
+	const seq_vector* envelope_freq,
+	size_t src_freq_first,
 	const seq_vector* travel_time,
 	double pulse_length, double threshold
 ) :
-	_transmit_freq(transmit_freq),
+	_envelope_freq(envelope_freq),
+	_src_freq_first(src_freq_first),
 	_travel_time( travel_time->clone() ),
 	_pulse_length( pulse_length ),
 	_threshold( threshold * pulse_length ),
-	_intensity(transmit_freq->size(), travel_time->size()),
-	_energy(transmit_freq->size()),
-	_duration(transmit_freq->size()),
+	_intensity(envelope_freq->size(), travel_time->size()),
+	_energy(envelope_freq->size()),
+	_duration(envelope_freq->size()),
 	_time_vector( _travel_time->data() ),
 	_level(travel_time->size())
 {
@@ -51,7 +53,7 @@ bool envelope_model::compute_intensity(
 	bool ok = compute_overlap( src_verb, rcv_verb, scatter, xs2, ys2 );
 	if ( !ok ) return false ;
 
-	compute_time_series( src_verb, rcv_verb ) ;
+	compute_time_series( src_verb.time, rcv_verb.time ) ;
 	return true ;
 }
 
@@ -84,11 +86,22 @@ bool envelope_model::compute_overlap(
 // 		 << " cos2alpha=" << cos2alpha
 //		 << " sin2alpha=" << sin2alpha << endl ;
 
+	// define subset of frequency dependent terms in source
+    //
+    // Although the use of const_cast<> allows us to ignore the read-only
+    // nature of src_verb, we are *very careful* to not write anything to it.
+
+	range window( _src_freq_first, _src_freq_first + _envelope_freq->size() ) ;
+	eigenverb& verb = const_cast<eigenverb&>( src_verb ) ;
+	const vector_range< vector<double> > src_verb_length2( verb.length2, window ) ;
+	const vector_range< vector<double> > src_verb_width2( verb.width2, window ) ;
+	const vector_range< vector<double> > src_verb_energy( verb.energy, window ) ;
+
     // compute the intersection of the Gaussian profiles
 
-    vector<double> src_sum = src_verb.length2 + src_verb.width2 ;
-    vector<double> src_diff = src_verb.length2 - src_verb.width2 ;
-    vector<double> src_prod = src_verb.length2 * src_verb.width2 ;
+    vector<double> src_sum = src_verb_length2 + src_verb_width2 ;
+    vector<double> src_diff = src_verb_length2 - src_verb_width2 ;
+    vector<double> src_prod = src_verb_length2 * src_verb_width2 ;
 //    cout << "src_sum=" << src_sum
 // 		 << " src_diff=" << src_diff
 //		 << " src_prod=" << src_prod << endl ;
@@ -106,7 +119,7 @@ bool envelope_model::compute_overlap(
     vector<double> det_sr = 0.5 * ( 2.0 * ( src_prod + rcv_prod )
     		+ ( src_sum * rcv_sum ) - ( src_diff * rcv_diff ) * cos2alpha ) ;
     noalias(_energy) = element_div(
-    		TWO_PI * src_verb.energy * rcv_verb.energy * scatter,
+    		TWO_PI * src_verb_energy * rcv_verb.energy * scatter,
 			sqrt( det_sr ) ) ;
 //    cout << "det_sr=" << det_sr
 // 		 << " energy=" << _energy << endl ;
@@ -191,20 +204,21 @@ bool envelope_model::compute_overlap(
  * total energy.
  */
 void envelope_model::compute_time_series(
-	const eigenverb& src_verb, const eigenverb& rcv_verb )
+		double src_verb_time, double rcv_verb_time )
 {
 	const double coeff = 1.0 / (4.0 * M_PI * sqrt(TWO_PI));
 	_intensity.clear() ;
-	for (size_t f = 0; f < _transmit_freq->size(); ++f) {
+
+	for ( size_t f = 0 ;f < _envelope_freq->size(); ++f ) {
 
 		// compute the peak time and intensity
 
-		double delay = src_verb.time + rcv_verb.time + _duration[f];
+		double delay = src_verb_time + rcv_verb_time + _duration[f];
 		double scale = _energy[f] * coeff / _duration[f];
 
 		// compute Gaussian intensity as a function of time
 		//
-		// TODO Test to see if using uBLAS vector proxies to limit computation is faster
+		// TODO Test to see if using uBLAS vector proxies to limit computation is faster (issue #189)
 
 		matrix_row< matrix<double> > intensity( _intensity, f ) ;
 

--- a/eigenverb/envelope_model.cc
+++ b/eigenverb/envelope_model.cc
@@ -30,16 +30,8 @@ envelope_model::envelope_model(
 	_intensity(envelope_freq->size(), travel_time->size()),
 	_energy(envelope_freq->size()),
 	_duration(envelope_freq->size()),
-	_time_vector(_travel_time->data()),
-//	_time_vector(_travel_time->size()),
 	_level(travel_time->size())
 {
-//	// copy data from the _travel_time's unbounded_array
-//	// to _time_vector's vector<double> as a work around
-//	// to a shortcoming in Boost 1.41
-//
-//	std::copy( _travel_time->data().begin(), _travel_time->data().end(),
-//			_time_vector.begin()) ;
 }
 
 /**
@@ -238,7 +230,7 @@ void envelope_model::compute_time_series(
 			size_t first = _travel_time->find_index(delay - 5.0 * _duration[f]);
 			size_t last = _travel_time->find_index(delay + 5.0 * _duration[f]) + 1;
 			range window(first, last);
-			vector_range< vector<double> > time(_time_vector, window);
+			vector_range< seq_vector > time(*_travel_time, window);
 			vector_range< vector<double> > level(_level, window);
 			level = scale * exp(-0.5 * abs2((time - delay) / _duration[f]));
 			intensity = _level ;
@@ -248,8 +240,8 @@ void envelope_model::compute_time_series(
 			// compute intensity at all times
 
 			intensity = scale * exp(-0.5 * abs2(
-					(_time_vector - delay) / _duration[f]));
-			cout << "f=" << f << " " << intensity << endl ;
+					(*_travel_time - delay) / _duration[f]));
+//			cout << "f=" << f << " " << intensity << endl ;
 		#endif
 	}
 }

--- a/eigenverb/envelope_model.h
+++ b/eigenverb/envelope_model.h
@@ -201,14 +201,6 @@ private:
 	vector<double> _duration ;
 
 	/**
-	 * Times in the form of a uBLAS vector.  This is used as the independent
-	 * variable during compute_time_series().
-	 * Making is a member variable prevents us from having to
-	 * rebuilt it for each calculation.
-	 */
-	vector<double> _time_vector ;
-
-	/**
 	 * Workspace for storing intensity as a function of time (linear units).
 	 * The Gaussian contributions from each eigenverb overlap are added
 	 * to this object, and then this object is copied into the appropriate

--- a/eigenverb/envelope_model.h
+++ b/eigenverb/envelope_model.h
@@ -19,7 +19,12 @@ class envelope_collection ; // forward declaration
  * Computes the reverberation envelope time series for a single combination of
  * receiver azimuth, source beam number, receiver beam number. The envelope is
  * stored as a matrix that represents the results a function of the
- * sensor_pair's transmit frequency (rows) and two-way travel time (columns).
+ * sensor_pair's envelope frequency (rows) and two-way travel time (columns).
+ *
+ * This implementation requires the receiver eigenverbs to be interpolated
+ * onto the envelope frequencies.  However, to save time, it assumes that
+ * the envelope frequencies are a subset of the source eigenverbs frequencies,
+ * so that no interpolation is required.
  *
  * There are no public methods in this class.  It just acts as a set of service
  * routines for the envelope_collection class.
@@ -37,17 +42,22 @@ private:
 	/**
 	 * Reserve the memory used to store the results of this calculation.
 	 *
-	 * @param transmit_freq	Frequencies at which the source and receiver
-	 * 						eigenverbs are computed (Hz).
-	 * @param travel_time	Times at which the sensor_pair's
-	 * 						reverberation envelopes are computed (Hz).
-	 * @param pulse_length	Duration of the transmitted pulse (sec).
-	 * 						Defines the temporal resolution of the envelope.
-	 * @param threshold		Minimum intensity level for valid reverberation
-	 * 						contributions (linear units).
+	 * @param envelope_freq		Frequencies at which the source and receiver
+	 * 							eigenverbs overlap (Hz).  Frequencies at which
+	 * 							envelope will be computed.
+	 * @param src_freq_first	Index of the first source frequency that
+	 * 							overlaps receiver (Hz).  Used to map
+	 * 							source eigenverbs onto envelope_freq values.
+	 * @param travel_time		Times at which the sensor_pair's
+	 * 							reverberation envelopes are computed (Hz).
+	 * @param pulse_length		Duration of the transmitted pulse (sec).
+	 * 							Defines the temporal resolution of the envelope.
+	 * @param threshold			Minimum intensity level for valid reverberation
+	 * 							contributions (linear units).
 	 */
 	envelope_model(
-		const seq_vector* transmit_freq,
+		const seq_vector* envelope_freq,
+		size_t src_freq_first,
 		const seq_vector* travel_time,
 		double pulse_length, double threshold
 	) ;
@@ -65,8 +75,10 @@ private:
 	 * has computed the scattering coefficient; which saves this
 	 * class from having to know anything about the ocean.
 	 *
-	 * @param src_verb		Eigenverb contribution from the source.
-	 * @param rcv_verb		Eigenverb contribution from the receiver.
+	 * @param src_verb		Eigenverb contribution from the source
+	 * 						at the original source frequencies.
+	 * @param rcv_verb		Eigenverb contribution from the receiver
+	 * 						interpolated onto the envelope frequencies.
 	 * @param scatter		Scattering strength coefficient for this
 	 * 						combination of eigenverbs (ratio).
 	 * @param xs2			Square of the relative distance from the
@@ -84,7 +96,7 @@ private:
 
 	/**
 	 * Reverberation intensity at each point the time series.
-	 * Each row represents a specific transmit frequency.
+	 * Each row represents a specific envelope frequency.
 	 * Each column represents a specific travel time.
 	 * Passing this back as a non-const reference allows it to be accessed
 	 * by a matrix_row<> proxy in the calling program.
@@ -101,11 +113,13 @@ private:
 	 * the bistatic reverberation contribution from eqn. (28) ans (29)
 	 * in the paper.  Computes the duration from eqn. (45) and (33).
 	 *
-	 * @param src_verb		Eigenverb contribution from the source.
-	 * @param rcv_verb		Eigenverb contribution from the receiver.
+	 * @param src_verb		Eigenverb contribution from the source,
+	 * 						at the original source frequencies.
+	 * @param rcv_verb		Eigenverb contribution from the receiver,
+	 * 						interpolated onto the envelope frequencies.
 	 * @param scatter		Scattering strength coefficient for this
 	 * 						combination of eigenverbs,
-	 * 						as a function of transmit frequency (ratio).
+	 * 						as a function of envelope frequency (ratio).
 	 * @param xs2			Square of the relative distance from the
 	 * 						receiver to the target along the direction
 	 * 						of the receiver's length.
@@ -128,16 +142,22 @@ private:
 	 * portion of the time series within +/- five (5) times the duration
 	 * of each pulse.
 	 *
-	 * @param src_verb		Eigenverb contribution from the source.
-	 * @param rcv_verb		Eigenverb contribution from the receiver.
+	 * @param src_verb		One way travel time for source eigenverb.
+	 * @param rcv_verb		One way travel time for receiver eigenverb.
 	 */
-	void compute_time_series(
-			const eigenverb& src_verb, const eigenverb& rcv_verb ) ;
+	void compute_time_series( double src_verb_time, double rcv_verb_time ) ;
 
 	/**
-	 * Frequencies at which the source and receiver eigenverbs are computed (Hz).
+	 * Frequencies at which the source and receiver eigenverbs overlap (Hz).
+	 * Frequencies at which envelope will be computed.
 	 */
-	const seq_vector* _transmit_freq ;
+	const seq_vector* _envelope_freq ;
+
+	/**
+	 * Index of the first source frequency that overlaps receiver (Hz).
+	 * Used to map source eigenverbs onto envelope_freq values.
+	 */
+	const size_t _src_freq_first ;
 
 	/**
 	 * Times at which the sensor_pair's reverberation envelopes
@@ -163,24 +183,20 @@ private:
 
 	/**
 	 * Reverberation intensity at each point the time series.
-	 * Each row represents a specific transmit frequency.
+	 * Each row represents a specific envelope frequency.
 	 * Each column represents a specific travel time.
 	 */
 	matrix< double > _intensity;
 
 	/**
 	 * Workspace for storing total energy of eigenverb overlap,
-	 * as a function of transmit frequency (linear units).
-	 * Making is a member variable prevents us from having to
-	 * rebuilt it for each calculation.
+	 * as a function of envelope frequency (linear units).
 	 */
 	vector<double> _energy ;
 
 	/**
 	 * Workspace for storing duration result of eigenverb overlap,
-	 * as a function of transmit frequency (sec).
-	 * Making is a member variable prevents us from having to
-	 * rebuilt it for each calculation.
+	 * as a function of envelope frequency (sec).
 	 */
 	vector<double> _duration ;
 

--- a/eigenverb/test/eigenverb_test.cc
+++ b/eigenverb/test/eigenverb_test.cc
@@ -396,14 +396,14 @@ BOOST_AUTO_TEST_CASE( envelope_interpolate ) {
 
 	src_verb.time = 5.0 ;
 	rcv_verb.time = 5.0 ;
-	collection.add_contribution( src_verb, src_verb,
+	collection.add_contribution( src_verb, rcv_verb,
 		src_beam, rcv_beam, scatter, 0.0, 0.0 ) ;
 
 	src_verb.time = 15.0 ;
 	rcv_verb.time = 15.0 ;
 	src_verb.energy *= 0.5 ;
 	rcv_verb.energy *= 0.5 ;
-	collection.add_contribution( src_verb, src_verb,
+	collection.add_contribution( src_verb, rcv_verb,
 			src_beam, rcv_beam, scatter, 0.0, 0.0 ) ;
 
 	collection.write_netcdf(ncname) ;

--- a/eigenverb/test/eigenverb_test.cc
+++ b/eigenverb/test/eigenverb_test.cc
@@ -240,6 +240,8 @@ BOOST_AUTO_TEST_CASE( envelope_basic ) {
 		1, 				// num_src_beams
 		1 ) ; 			// num_rcv_beams
 
+    delete travel_time;
+
 	vector<double> scatter( freq.size() ) ;
 	matrix<double> src_beam( freq.size(), 1 ) ;
 	matrix<double> rcv_beam( freq.size(), 1 ) ;
@@ -379,6 +381,8 @@ BOOST_AUTO_TEST_CASE( envelope_interpolate ) {
 		1, 				// num_azimuths
 		1, 				// num_src_beams
 		1 ) ; 			// num_rcv_beams
+
+    delete travel_time;
 
 	vector<double> scatter( envelope_freq.size() ) ;
 	matrix<double> src_beam( envelope_freq.size(), 1 ) ;

--- a/eigenverb/test/eigenverb_test.cc
+++ b/eigenverb/test/eigenverb_test.cc
@@ -8,6 +8,7 @@
 #include <usml/waveq3d/waveq3d.h>
 #include <usml/eigenverb/eigenverb_collection.h>
 #include <usml/eigenverb/envelope_collection.h>
+#include <usml/eigenverb/eigenverb_interpolator.h>
 
 BOOST_AUTO_TEST_SUITE(eigenverb_test)
 
@@ -232,7 +233,8 @@ BOOST_AUTO_TEST_CASE( envelope_basic ) {
 
 	const seq_vector* travel_time = new seq_linear(0.0,0.1,400.0) ;
 	envelope_collection collection(
-		&freq,			// transmit_freq
+		&freq,			// envelope_freq
+		0,				// src_freq_first
 		travel_time,	// travel_time  ownership passed into envelope_collection
 		40.0,			// reverb_duration
 		1.0, 			// pulse_length
@@ -272,6 +274,149 @@ BOOST_AUTO_TEST_CASE( envelope_basic ) {
 		- 10.0*log10(coeff * 0.5);
 	size_t index = 105 ;
 	for (size_t f = 0; f < freq.size(); ++f) {
+		double model = 10.0*log10(collection.envelope(0,0,0)(f,index));
+		cout << "theory=" << theory[f] << " model=" << model << endl;
+		BOOST_CHECK_CLOSE(theory[f], model, 1e-2);
+	}
+}
+
+/**
+ * Test the ability to compute source and receiver eigenverbs at different
+ * frequencies.  Similar to envelope_basic test except that:
+ *
+ * 		- source and receiver are at different frequencies
+ * 		- receiver is interpolated onto envelope frequency axis
+ * 		- result is limited to first two source frequencies
+ */
+BOOST_AUTO_TEST_CASE( envelope_interpolate ) {
+    cout << "=== eigenverb_test: envelope_interpolate ===" << endl;
+    const char* ncname = USML_TEST_DIR "/eigenverb/test/envelope_interpolate.nc";
+
+    // setup scenario for 30 deg D/E in 1000 meters of water
+
+    double angle = M_PI / 6.0 ;
+    double depth = 1000.0 ;
+    double range = sqrt(3) * depth / ( 1852.0 * 60.0 );
+
+	// build a simple source eigenverb
+
+	eigenverb src_verb ;
+	src_verb.time = 0.0 ;
+	src_verb.position = wposition1(range,0.0,-depth) ;
+	src_verb.direction = 0.0 ;
+	src_verb.grazing = angle ;
+	src_verb.sound_speed = c0 ;
+	src_verb.de_index = 0 ;
+	src_verb.az_index = 0 ;
+	src_verb.source_de = -angle ;
+	src_verb.source_az = 0.0 ;
+	src_verb.surface = 0 ;
+	src_verb.bottom = 0 ;
+	src_verb.caustic = 0 ;
+	src_verb.upper = 0 ;
+	src_verb.lower = 0 ;
+
+	seq_linear src_freq(1000.0,1000.0,3) ;
+	src_verb.frequencies = &src_freq ;
+	src_verb.energy = vector<double>( src_freq.size() ) ;
+	src_verb.length2 = vector<double>( src_freq.size() ) ;
+	src_verb.width2 = vector<double>( src_freq.size() ) ;
+	for ( size_t f=0 ; f < src_freq.size() ; ++f ) {
+		src_verb.energy[f] = 0.2 ;
+		src_verb.length2[f] = 400.0 + 10.0 * f ;
+		src_verb.width2[f] = 100.0 + 10.0 * f ;
+	}
+
+	// build a simple receiver eigenverb
+	// identical to src_verb except for frequency axis
+
+	eigenverb rcv_verb_original ;
+	rcv_verb_original.time = 0.0 ;
+	rcv_verb_original.position = wposition1(range,0.0,-depth) ;
+	rcv_verb_original.direction = 0.0 ;
+	rcv_verb_original.grazing = angle ;
+	rcv_verb_original.sound_speed = c0 ;
+	rcv_verb_original.de_index = 0 ;
+	rcv_verb_original.az_index = 0 ;
+	rcv_verb_original.source_de = -angle ;
+	rcv_verb_original.source_az = 0.0 ;
+	rcv_verb_original.surface = 0 ;
+	rcv_verb_original.bottom = 0 ;
+	rcv_verb_original.caustic = 0 ;
+	rcv_verb_original.upper = 0 ;
+	rcv_verb_original.lower = 0 ;
+
+	seq_linear rcv_freq(500.0,200.0,10) ;
+	rcv_verb_original.frequencies = &rcv_freq ;
+	rcv_verb_original.energy = vector<double>( rcv_freq.size() ) ;
+	rcv_verb_original.length2 = vector<double>( rcv_freq.size() ) ;
+	rcv_verb_original.width2 = vector<double>( rcv_freq.size() ) ;
+	for ( size_t f=0 ; f < rcv_freq.size() ; ++f ) {
+		rcv_verb_original.energy[f] = 0.2 ;
+		rcv_verb_original.length2[f] = 400.0 + 10.0 * f ;
+		rcv_verb_original.width2[f] = 100.0 + 10.0 * f ;
+	}
+
+	// interpolate rcv_verb_original onto frequency axis of envelope
+
+	seq_linear envelope_freq( 1000.0, 1000.0, 2 ) ;
+	eigenverb rcv_verb ;
+	rcv_verb.frequencies = &envelope_freq ;
+	rcv_verb.energy = vector<double>( envelope_freq.size() ) ;
+	rcv_verb.length2 = vector<double>( envelope_freq.size() ) ;
+	rcv_verb.width2 = vector<double>( envelope_freq.size() ) ;
+
+	eigenverb_interpolator interpolator( &rcv_freq,  &envelope_freq ) ;
+	interpolator.interpolate( rcv_verb_original, &rcv_verb ) ;
+
+	// construct an envelope_collection
+
+	const seq_vector* travel_time = new seq_linear(0.0,0.1,400.0) ;
+	envelope_collection collection(
+		&envelope_freq,			// envelope_freq
+		0,				// src_freq_first
+		travel_time,	// travel_time  ownership passed into envelope_collection
+		40.0,			// reverb_duration
+		1.0, 			// pulse_length
+		1e-30,			// threshold
+		1, 				// num_azimuths
+		1, 				// num_src_beams
+		1 ) ; 			// num_rcv_beams
+
+	vector<double> scatter( envelope_freq.size() ) ;
+	matrix<double> src_beam( envelope_freq.size(), 1 ) ;
+	matrix<double> rcv_beam( envelope_freq.size(), 1 ) ;
+	for ( size_t f=0 ; f < envelope_freq.size() ; ++f ) {
+		scatter[f] = 0.1 + 0.01 * f ;
+		src_beam(f,0) = 1.0 ;
+		rcv_beam(f,0) = 1.0 ;
+	}
+
+	// add contributions at t=10 and t=30 sec
+
+	src_verb.time = 5.0 ;
+	rcv_verb.time = 5.0 ;
+	collection.add_contribution( src_verb, src_verb,
+		src_beam, rcv_beam, scatter, 0.0, 0.0 ) ;
+
+	src_verb.time = 15.0 ;
+	rcv_verb.time = 15.0 ;
+	src_verb.energy *= 0.5 ;
+	rcv_verb.energy *= 0.5 ;
+	collection.add_contribution( src_verb, src_verb,
+			src_beam, rcv_beam, scatter, 0.0, 0.0 ) ;
+
+	collection.write_netcdf(ncname) ;
+
+	// compare total energy to analytic solution for monostatic result (eqn. 31).
+
+	const double coeff = 4.0 * M_PI * sqrt(TWO_PI) ;
+	vector<double> theory = 10.0*log10(element_div(
+		M_PI * 0.2 * 0.2 * scatter,
+		sqrt(src_verb.length2 * src_verb.width2)))
+		- 10.0*log10(coeff * 0.5);
+	size_t index = 105 ;
+	for (size_t f = 0; f < envelope_freq.size(); ++f) {
 		double model = 10.0*log10(collection.envelope(0,0,0)(f,index));
 		cout << "theory=" << theory[f] << " model=" << model << endl;
 		BOOST_CHECK_CLOSE(theory[f], model, 1e-2);

--- a/studies/reverberation/reverb_analytic_test.cc
+++ b/studies/reverberation/reverb_analytic_test.cc
@@ -114,7 +114,9 @@ private:
 
 		source_params::reference source(
 				new source_params(paramsID, source_level,
-                6000.0, 9000.0,             // min, max active freq
+                0.250,                               // pulse_length
+                wavefront_generator::time_maximum,   // reverb_duration
+                6000.0, 9000.0,                      // min, max active freq
                 source_frequencies, source_beams, multistatic));
 		source_params_map::instance()->insert(source->paramsID(), source);
 
@@ -145,7 +147,7 @@ private:
 		sensor_manager::instance()->add_sensor(sensorID, paramsID, "sensor1");
 
 		// Set wave_queue attributes
-		wavefront_generator::time_maximum = 1.0; // sec
+		wavefront_generator::time_maximum =  7.0/2.0;     // reverb_duration/2
 		wavefront_generator::intensity_threshold = 150.0; //dB
 
 		// Update sensor data and run wave_queue.

--- a/studies/reverberation/reverb_analytic_test.cc
+++ b/studies/reverberation/reverb_analytic_test.cc
@@ -88,7 +88,7 @@ private:
 	 * <pre>
 	 * multistatic:			false
 	 * source strength:     200 dB
-	 * transmit frequency:  3 KHz
+	 * envelope frequency:  3 KHz
 	 * src beam pattern:    omni directional
 	 * rcv beam pattern: 	omni directional
 	 * </pre>

--- a/waveq3d/test/reflection_test.cc
+++ b/waveq3d/test/reflection_test.cc
@@ -34,8 +34,8 @@ public:
     double latitude ;
     bool surface ;
     bool bottom ;
-    int surf_count ;
-    int bot_count ;
+    size_t surf_count ;
+    size_t bot_count;
 
     /**
      * Initialize counter.
@@ -47,7 +47,7 @@ public:
 
     virtual ~reflection_callback() {}
 
-    bool check_count( int& old_count ) {
+    bool check_count( size_t& old_count ) {
         bottom = surface = false ;
         if( surf_count != _collection->eigenverbs(1).size() ) {
             surf_count = _collection->eigenverbs(1).size() ;
@@ -150,7 +150,7 @@ BOOST_AUTO_TEST_CASE( reflect_flat_test ) {
         eigenverb_collection verb_collection( 0 ) ;
         wave.add_eigenverb_listener( &verb_collection ) ;
         reflection_callback callback( &verb_collection ) ;
-        int old_count = callback.surf_count + callback.bot_count ;
+        size_t old_count = callback.surf_count + callback.bot_count ;
         double max_time_error = 0.0 ;
         double max_lat_error = 0.0 ;
 


### PR DESCRIPTION
- Define subset of frequency dependent source eigenverb terms in
  envelope_model::compute_overlap() method.  Uses src_freq_first
  and envelope_freq->size() to create a vector proxy sub-set.
- Pass src_freq_first into envelope_generator, envelope_collection,
  and envelope_model constructors so that it is available for sub-setting.
- Change the arguments of envelope_model::compute_time_series() from
  eigenverb reference to double time values.  Only eigenverb.time was
  actually being used in compute_time_series().
- Change transmit_freq to envelope_freq, because the old name was
  confusing people.
- Create a new test, called eigenverb_test/envelope_interpolate,
  specifically to test receiver eigenverb interpolation and source
  eigenverb subsetting.  Similar to envelope_basic test except that:
  - source and receiver are at different frequencies
  - receiver is interpolated onto envelope frequency axis
  - result is limited to first two source frequencies
- Word smithing on many of the JavaDoc comments.
- Resolves #185