### PR TITLE
Augmented seq_vectors at vector upper/lower bounds

### DIFF
--- a/eigenverb/wavefront_generator.h
+++ b/eigenverb/wavefront_generator.h
@@ -170,12 +170,6 @@ private:
      */
     const double _intensity_threshold; //In dB
 
-    /** Depression elevation angle in degrees */
-    const double  _depression_elevation_angle;
-
-    /** Vertical beam width in degrees*/
-    const double  _vertical_beamwidth;
-
     /** Source position */
     const wposition1 _source_position;
 

--- a/types/seq_augment.h
+++ b/types/seq_augment.h
@@ -1,0 +1,88 @@
+/**
+ * @file seq_augment.h
+ * Augments a seq_vector to produce more rays in the vertical directions.
+ */
+#pragma once
+
+#include <usml/types/seq_data.h>
+
+namespace usml {
+namespace types {
+
+/// @ingroup data_grid
+/// @{
+
+/**
+ * Augments a seq_vector to include more rays in the vertical direction.
+ * This augment seq_vector is commonly used when attempting to produce
+ * eigenrays for a monostatic target/sensor scenario.
+ */
+class USML_DECLSPEC seq_augment : public seq_data {
+
+public:
+
+    /**
+     * Constructor
+     * Takes an unaugmented seq_vector and adds a specified number of
+     * linearly spaced rays to the edges of the vector. ie, if 6 rays
+     * are to be added to the seq_vector, 3 new rays will be created
+     * at the upper and lower extreme of the seq_vector.
+     *
+     * @param origin    seq_vector to augment
+     * @param num_rays  number of rays to increase the vector by
+     */
+    seq_augment( const seq_vector* origin, size_t num_rays )
+        : seq_data( origin->size()+num_rays )
+    {
+        initialize( origin, num_rays ) ;
+    }
+
+    /**
+     * Destructor
+     */
+    virtual ~seq_augment() {}
+
+protected:
+
+    /**
+     * Creates a new sequence from an unaugmented sequence
+     *
+     * @param origin    unagumented seq_vector
+     * @param num_rays  number of rays to add to the seq_vector
+     */
+    void initialize( const seq_vector* origin, size_t num_rays ) {
+        size_t size_old( origin->size() ) ;
+        size_t size( size_old + num_rays ) ;
+        _index = 0 ;
+        _sign = 1.0;
+        _max_index = size - 1 ;
+        _data.resize(size) ;
+        _increment.resize(size) ;
+
+        double first = (*origin)[0] ;
+        _value = _index_data = first ;
+        size_t half = floor(num_rays/2)+1 ;
+        double spacing = origin->increment(0) / half ;
+        _data[0] = first ;
+        for(size_t i=1; i<half+1; ++i) {
+            _data[i] = _data[i-1] + spacing ;
+        }
+        double* d = _data.begin()+half+1 ;
+        double* od = origin->data().begin() ;
+        memcpy(d, (od+2), sizeof(double)*(size_old-2) ) ;
+        for(size_t i=size_old-2+half; i<size-1; ++i) {
+            _data[i] = _data[i-1] + spacing ;
+        }
+        _data[size-1] = (*origin)[size_old-1] ;
+
+        for(size_t i=1; i<size-1; ++i) {
+            _increment[i-1] = _data[i] - _data[i-1] ;
+        }
+        _increment[_max_index] = _data[_max_index] - _data[_max_index-1] ;
+    }
+
+};
+
+/// @}
+}   // end of namespace types
+}   // end of namespace usml

--- a/types/test/sequence_test.cc
+++ b/types/test/sequence_test.cc
@@ -340,7 +340,7 @@ BOOST_AUTO_TEST_CASE( sequence_data_test3 ) {
 
     cout << "=== sequence_test: sequence_data_test3() ===" << endl;
 
-    // test decreasing sequence form of contructor
+    // test decreasing sequence form of constructor
     // test use as a uBLAS vector
     int N = 1;
     double data[] = {123.5};
@@ -523,6 +523,8 @@ BOOST_AUTO_TEST_CASE( seq_ublas_test ) {
 
 /**
  * Tests the seq_vector::clip method
+ * Test fails if any the clipped values are
+ * not equal to the predetermined correct values.
  */
 BOOST_AUTO_TEST_CASE( seq_vector_clip_test ) {
     cout << "=== sequence_test/seq_vector_clip_test ===" << endl ;
@@ -530,9 +532,12 @@ BOOST_AUTO_TEST_CASE( seq_vector_clip_test ) {
      // 6.5K, 7.5K, 8.5K, 9.5K
     seq_linear values(6500.0, 1000.0, 4);
 
+    cout << "original values: " << values << endl ;
+
     // Max Clip
     seq_vector* clipped_values_one = values.clip(5000.0, 9000.0);
 
+    cout << "after max clip :  " <<  *clipped_values_one << endl ;
     BOOST_CHECK_EQUAL( clipped_values_one->size(), 3 ) ;
 
     double test_value = (*clipped_values_one)(0);
@@ -546,6 +551,7 @@ BOOST_AUTO_TEST_CASE( seq_vector_clip_test ) {
     // Min clip
     seq_vector* clipped_values_two = values.clip(7000.0, 11000.0);
 
+    cout << "after min clip:  " << *clipped_values_two << endl ;
     BOOST_CHECK_EQUAL( clipped_values_two->size(), 3 ) ;
 
     test_value = (*clipped_values_two)(0);
@@ -560,6 +566,7 @@ BOOST_AUTO_TEST_CASE( seq_vector_clip_test ) {
     // Max and Min clip
     seq_vector* clipped_values_three = values.clip(7000.0, 9000.0);
 
+    cout << "after max and min clip:  " << *clipped_values_three << endl ;
     BOOST_CHECK_EQUAL( clipped_values_three->size(), 2 ) ;
 
     test_value = (*clipped_values_three)(0);
@@ -577,10 +584,12 @@ BOOST_AUTO_TEST_CASE( seq_vector_clip_test ) {
 BOOST_AUTO_TEST_CASE( seq_augment_test ) {
     cout << "=== sequence_test/seq_augment_test ===" << endl ;
 
-    seq_linear origin( 6.0, 1.0, 5 ) ;
+    //seq_linear origin( 6.0, 1.0, 5 ) ;
+    seq_rayfan origin(6.0, 10.0, 5);
     size_t N = 6 ;
 
-    double tmp[] = { 6.0, 6.25, 6.5, 6.75, 7.0, 8.0, 9.0, 9.25, 9.5, 9.75, 10.0 } ;
+    //double tmp[] = { 6.0, 6.25, 6.5, 6.75, 7.0, 8.0, 9.0, 9.25, 9.5, 9.75, 10.0 } ;
+    double tmp[]= { 6.0,6.19598,6.39196,6.58795,6.78393,7.68466,8.73893,8.93492,9.1309,9.32688,10.0 };
     size_t size( sizeof(tmp)/sizeof(double) ) ;
     vector<double> data( size, 0.0 ) ;
     size_t index = 0 ;
@@ -589,11 +598,12 @@ BOOST_AUTO_TEST_CASE( seq_augment_test ) {
     seq_data truth( data ) ;
 
     seq_augment aug( &origin, N) ;
+    cout << std::setprecision(8);
     cout << "origin: " << origin << endl ;
     cout << "augment: " << aug << endl ;
     index = 0 ;
     BOOST_FOREACH( double i, aug )
-        BOOST_CHECK_EQUAL( i, tmp[index++] ) ;
+        BOOST_CHECK_CLOSE( i, tmp[index++], 0.0001 ) ;
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/types/test/sequence_test.cc
+++ b/types/test/sequence_test.cc
@@ -569,4 +569,31 @@ BOOST_AUTO_TEST_CASE( seq_vector_clip_test ) {
     delete clipped_values_three;
 }
 
+/**
+ * Tests the implementation of seq_augment
+ * Test fails if any values are unequal to the
+ * predetermined truth vector.
+ */
+BOOST_AUTO_TEST_CASE( seq_augment_test ) {
+    cout << "=== sequence_test/seq_augment_test ===" << endl ;
+
+    seq_linear origin( 6.0, 1.0, 5 ) ;
+    size_t N = 6 ;
+
+    double tmp[] = { 6.0, 6.25, 6.5, 6.75, 7.0, 8.0, 9.0, 9.25, 9.5, 9.75, 10.0 } ;
+    size_t size( sizeof(tmp)/sizeof(double) ) ;
+    vector<double> data( size, 0.0 ) ;
+    size_t index = 0 ;
+    BOOST_FOREACH( double& i, data )
+        i = tmp[index++] ;
+    seq_data truth( data ) ;
+
+    seq_augment aug( &origin, N) ;
+    cout << "origin: " << origin << endl ;
+    cout << "augment: " << aug << endl ;
+    index = 0 ;
+    BOOST_FOREACH( double i, aug )
+        BOOST_CHECK_EQUAL( i, tmp[index++] ) ;
+}
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/types/types.h
+++ b/types/types.h
@@ -49,6 +49,7 @@
 #include <usml/types/seq_log.h>
 #include <usml/types/seq_data.h>
 #include <usml/types/seq_rayfan.h>
+#include <usml/types/seq_augment.h>
 
 #include <usml/types/data_grid.h>
 #include <usml/types/data_grid_bathy.h>


### PR DESCRIPTION
Resolves #141 by adding a new seq_vector class called seq_augment that augments the passed in seq_vector to add new entries at the upper and lower limits of the container. This new class is of particular use to monostatic scenarios, where eigenrays are required to be produced by the source as its own target.