### PR TITLE
Extend data grid

### DIFF
--- a/types/data_grid_functors.h
+++ b/types/data_grid_functors.h
@@ -1,0 +1,328 @@
+#pragma once
+
+#include <boost/numeric/ublas/vector.hpp>
+#include <boost/numeric/ublas/matrix.hpp>
+
+namespace usml {
+namespace types {
+
+/**
+ * Base functor for derivatives
+ */
+template<typename T>
+struct derivative {
+    typedef T  argument_type ;
+
+    static void compute(
+        argument_type d0, argument_type d1, argument_type dd0, argument_type dd1,
+        const argument_type w0, const argument_type w1, bool deriv,
+        argument_type& m, argument_type& dm )
+    {
+        if( d0 * d1 > 0.0 ) {
+            m = (w0 + w1) / ( w0 / d0 + w1 / d1 ) ;
+        }
+        if( deriv && dd0 * dd1 > 0.0 ) {
+            dm = (w0 + w1) / ( w0 / dd0 + w1 / dd1 ) ;
+        }
+    }
+};
+
+/**
+ * Specialized functor for derivatives
+ * used for ublas::vector<T>
+ */
+template<typename T>
+struct derivative< boost::numeric::ublas::vector<T> > {
+    typedef T  value_type ;
+    typedef std::size_t    size_type ;
+    typedef boost::numeric::ublas::vector<value_type>  argument_type ;
+
+    static void compute(
+        argument_type d0, argument_type d1, argument_type dd0, argument_type dd1,
+        const value_type w0, const value_type w1, bool deriv,
+        argument_type& m, argument_type& dm )
+    {
+        size_type size( d0.size() ) ;
+        for(size_type i=0; i<size; ++i) {
+            if( d0(i) * d1(i) > 0.0 ) {
+                m(i) = (w0 + w1) / ( w0 / d0(i) + w1 / d1(i) ) ;
+            }
+            if( deriv && dd0(i) * dd1(i) > 0.0 ) {
+                dm(i) = (w0 + w1) / ( w0 / dd0(i) + w1 / dd1(i) ) ;
+            }
+        }
+    }
+};
+
+/**
+ * Specialized functor for derivatives
+ * used for ublas::vector<T>
+ */
+template<typename T>
+struct derivative< boost::numeric::ublas::matrix<T> > {
+    typedef T  value_type ;
+    typedef std::size_t    size_type ;
+    typedef boost::numeric::ublas::matrix<value_type>  argument_type ;
+
+    static void compute(
+        argument_type d0, argument_type d1, argument_type dd0, argument_type dd1,
+        const value_type w0, const value_type w1, bool deriv,
+        argument_type& m, argument_type& dm )
+    {
+        size_type size1( d0.size1() ) ;
+        size_type size2( d0.size2() ) ;
+        for(size_type i=0; i<size1; ++i) {
+            for(size_type j=0; j<size2; ++j) {
+                if( d0(i,j) * d1(i,j) > 0.0 ) {
+                    m(i,j) = (w0 + w1) / ( w0 / d0(i,j) + w1 / d1(i,j) ) ;
+                }
+                if( deriv && dd0(i,j) * dd1(i,j) > 0.0 ) {
+                    dm(i,j) = (w0 + w1) / ( w0 / dd0(i,j) + w1 / dd1(i,j) ) ;
+                }
+            }
+        }
+    }
+};
+
+/**
+ * Base functor for end point derivatives
+ */
+template<typename T>
+struct end_point_derivative {
+    typedef T  argument_type ;
+
+    static void compute(
+        argument_type d0, argument_type d1, argument_type dd0, argument_type dd1,
+        bool deriv, argument_type& m, argument_type& dm )
+    {
+        if( m * d0 < 0.0 ) {
+            m = 0.0 ;
+        } else if( (d0*d1 < 0.0) && (abs(m) > abs(3.0*d1)) ) {
+            m = 3.0*d1 ;
+        }
+        if( deriv ) {
+            if( dm * dd0 < 0.0 ) {
+                dm = 0.0 ;
+            } else if( (dd0*dd1 < 0.0) && (abs(dm) > abs(3.0*dd0)) ) {
+                dm = 3.0*dd0 ;
+            }
+        } else {
+            dm = argument_type(0) ;
+        }
+    }
+};
+
+/**
+ * Specialized functor for end point derivatives
+ * used for ublas::vector<T>
+ */
+template<typename T>
+struct end_point_derivative< boost::numeric::ublas::vector<T> > {
+    typedef T  value_type ;
+    typedef std::size_t    size_type ;
+    typedef boost::numeric::ublas::vector<value_type> argument_type ;
+    
+    static void compute(
+        argument_type d0, argument_type d1, argument_type dd0, argument_type dd1,
+        bool deriv, argument_type& m, argument_type& dm )
+    {
+        size_type size( d0.size() ) ;
+        for(size_type i=0; i<size; ++i) {
+            if( m(i) * d0(i) < 0.0 ) {
+                m(i) = 0.0 ;
+            } else if( (d0(i)*d1(i) < 0.0) && (abs(m(i)) > abs(3.0*d0(i))) ) {
+                m(i) = 3.0*d0(i) ;
+            }
+            if( deriv ) {
+                if( dm(i) * dd0(i) < 0.0 ) {
+                    dm(i) = 0.0 ;
+                } else if( (dd0(i)*dd1(i) < 0.0) && (abs(dm(i)) > abs(3.0*dd0(i))) ) {
+                    dm(i) = 3.0*dd0(i) ;
+                }
+            } else {
+                dm(i) = value_type(0) ;
+            }
+        }
+    }
+};
+
+/**
+ * Specialized functor for end point derivatives
+ * used for ublas::matrix<T>
+ */
+template<typename T>
+struct end_point_derivative< boost::numeric::ublas::matrix<T> > {
+    typedef T  value_type ;
+    typedef std::size_t    size_type ;
+    typedef boost::numeric::ublas::matrix<value_type> argument_type ;
+    
+    static void compute(
+        argument_type d0, argument_type d1, argument_type dd0, argument_type dd1,
+        bool deriv, argument_type& m, argument_type& dm )
+    {
+        size_type size1( d0.size1() ) ;
+        size_type size2( d0.size2() ) ;
+        for(size_type i=0; i<size1; ++i) {
+            for(size_type j=0; j<size2; ++j) {
+                if( m(i,j) * d0(i,j) < 0.0 ) {
+                    m(i,j) = 0.0 ;
+                } else if( (d0(i,j)*d1(i,j) < 0.0) && (abs(m(i,j)) > abs(3.0*d0(i,j))) ) {
+                    m(i,j) = 3.0*d0(i,j) ;
+                }
+                if( deriv ) {
+                    if( dm(i,j) * dd0(i,j) < 0.0 ) {
+                        dm(i,j) = 0.0 ;
+                    } else if( (dd0(i,j)*dd1(i,j) < 0.0) && (abs(dm(i,j)) > abs(3.0*dd0(i,j))) ) {
+                        dm(i,j) = 3.0*dd0(i,j) ;
+                    }
+                } else {
+                    dm(i,j) = value_type(0) ;
+                }
+            }
+        }
+    }
+};
+
+/**
+ * Base functor sets values to zero
+ */
+template<typename T>
+struct initialize {
+    typedef T  argument_type ;
+    typedef std::size_t    size_type ;
+    static void zero( argument_type& a1, const argument_type s )
+    {
+        a1 = argument_type(0) ;
+    }
+    static void zero( argument_type& a1, argument_type& a2,
+                      const argument_type s )
+    {
+        a1 = argument_type(0) ;
+        a2 = argument_type(0) ;
+    }
+    static void zero( argument_type& a1, argument_type& a2,
+                      argument_type& a3, const argument_type s )
+    {
+        a1 = argument_type(0) ;
+        a2 = argument_type(0) ;
+        a3 = argument_type(0) ;
+    }
+    static void zero( argument_type& a1, argument_type& a2,
+                      argument_type& a3, argument_type& a4,
+                      const argument_type s )
+    {
+        a1 = argument_type(0) ;
+        a2 = argument_type(0) ;
+        a3 = argument_type(0) ;
+        a4 = argument_type(0) ;
+    }
+    static void value( argument_type& a, const argument_type s, argument_type v )
+    {
+        a = v ;
+    }
+};
+
+/**
+ * Specialized functor that sets values to zero
+ * for ublas::vector<T>
+ */
+template<typename T>
+struct initialize< boost::numeric::ublas::vector<T> > {
+    typedef T  value_type ;
+    typedef std::size_t    size_type ;
+    typedef boost::numeric::ublas::vector<value_type>  argument_type ;
+    static void zero( argument_type& a1, const argument_type s )
+    {
+        a1.resize( s.size() ) ;
+        a1.clear() ;
+    }
+    static void zero( argument_type& a1, argument_type& a2,
+                      const argument_type s )
+    {
+        a1.resize( s.size() ) ;
+        a1.clear() ;
+        a2.resize( s.size() ) ;
+        a2.clear() ;
+    }
+    static void zero( argument_type& a1, argument_type& a2,
+                      argument_type& a3, const argument_type s )
+    {
+        a1.resize( s.size() ) ;
+        a1.clear() ;
+        a2.resize( s.size() ) ;
+        a2.clear() ;
+        a3.resize( s.size() ) ;
+        a3.clear() ;
+    }
+    static void zero( argument_type& a1, argument_type& a2,
+                      argument_type& a3, argument_type& a4,
+                      const argument_type s )
+    {
+        a1.resize( s.size() ) ;
+        a1.clear() ;
+        a2.resize( s.size() ) ;
+        a2.clear() ;
+        a3.resize( s.size() ) ;
+        a3.clear() ;
+        a4.resize( s.size() ) ;
+        a4.clear() ;
+    }
+    static void value( argument_type& a, const argument_type s, value_type v )
+    {
+        a = boost::numeric::ublas::vector<value_type>(s.size(), v) ;
+    }
+};
+
+/**
+ * Specialized functor that sets values to zero
+ * for ublas::matrix<T>
+ */
+template<typename T>
+struct initialize< boost::numeric::ublas::matrix<T> > {
+    typedef T  value_type ;
+    typedef std::size_t    size_type ;
+    typedef boost::numeric::ublas::matrix<value_type>  argument_type ;
+    static void zero( argument_type& a1, const argument_type s )
+    {
+        a1.resize( s.size1(), s.size2() ) ;
+        a1.clear() ;
+    }
+    static void zero( argument_type& a1, argument_type& a2,
+                      const argument_type s )
+    {
+        a1.resize( s.size1(), s.size2() ) ;
+        a1.clear() ;
+        a2.resize( s.size1(), s.size2() ) ;
+        a2.clear() ;
+    }
+    static void zero( argument_type& a1, argument_type& a2,
+                      argument_type& a3, const argument_type s )
+    {
+        a1.resize( s.size1(), s.size2() ) ;
+        a1.clear() ;
+        a2.resize( s.size1(), s.size2() ) ;
+        a2.clear() ;
+        a3.resize( s.size1(), s.size2() ) ;
+        a3.clear() ;
+    }
+    static void zero( argument_type& a1, argument_type& a2,
+                      argument_type& a3, argument_type& a4,
+                      const argument_type s )
+    {
+        a1.resize( s.size1(), s.size2() ) ;
+        a1.clear() ;
+        a2.resize( s.size1(), s.size2() ) ;
+        a2.clear() ;
+        a3.resize( s.size1(), s.size2() ) ;
+        a3.clear() ;
+        a4.resize( s.size1(), s.size2() ) ;
+        a4.clear() ;
+    }
+    static void value( argument_type& a, const argument_type s, value_type v )
+    {
+        a = boost::numeric::ublas::scalar_matrix<value_type>( s.size1(), s.size2(), v) ;
+    }
+};
+
+}   // end of namespace types
+}   // end of namespace usml

--- a/types/data_grid_functors.h
+++ b/types/data_grid_functors.h
@@ -2,6 +2,7 @@
 
 #include <boost/numeric/ublas/vector.hpp>
 #include <boost/numeric/ublas/matrix.hpp>
+#include <usml/usml_config.h>
 
 namespace usml {
 namespace types {
@@ -10,7 +11,7 @@ namespace types {
  * Base functor for derivatives
  */
 template<typename T>
-struct derivative {
+struct USML_DLLEXPORT derivative {
     typedef T  argument_type ;
 
     static void compute(
@@ -32,7 +33,7 @@ struct derivative {
  * used for ublas::vector<T>
  */
 template<typename T>
-struct derivative< boost::numeric::ublas::vector<T> > {
+struct USML_DLLEXPORT derivative< boost::numeric::ublas::vector<T> > {
     typedef T  value_type ;
     typedef std::size_t    size_type ;
     typedef boost::numeric::ublas::vector<value_type>  argument_type ;
@@ -59,7 +60,7 @@ struct derivative< boost::numeric::ublas::vector<T> > {
  * used for ublas::vector<T>
  */
 template<typename T>
-struct derivative< boost::numeric::ublas::matrix<T> > {
+struct USML_DLLEXPORT derivative< boost::numeric::ublas::matrix<T> > {
     typedef T  value_type ;
     typedef std::size_t    size_type ;
     typedef boost::numeric::ublas::matrix<value_type>  argument_type ;
@@ -88,7 +89,7 @@ struct derivative< boost::numeric::ublas::matrix<T> > {
  * Base functor for end point derivatives
  */
 template<typename T>
-struct end_point_derivative {
+struct USML_DLLEXPORT end_point_derivative {
     typedef T  argument_type ;
 
     static void compute(
@@ -117,7 +118,7 @@ struct end_point_derivative {
  * used for ublas::vector<T>
  */
 template<typename T>
-struct end_point_derivative< boost::numeric::ublas::vector<T> > {
+struct USML_DLLEXPORT end_point_derivative< boost::numeric::ublas::vector<T> > {
     typedef T  value_type ;
     typedef std::size_t    size_type ;
     typedef boost::numeric::ublas::vector<value_type> argument_type ;
@@ -151,7 +152,7 @@ struct end_point_derivative< boost::numeric::ublas::vector<T> > {
  * used for ublas::matrix<T>
  */
 template<typename T>
-struct end_point_derivative< boost::numeric::ublas::matrix<T> > {
+struct USML_DLLEXPORT end_point_derivative< boost::numeric::ublas::matrix<T> > {
     typedef T  value_type ;
     typedef std::size_t    size_type ;
     typedef boost::numeric::ublas::matrix<value_type> argument_type ;
@@ -187,7 +188,7 @@ struct end_point_derivative< boost::numeric::ublas::matrix<T> > {
  * Base functor sets values to zero
  */
 template<typename T>
-struct initialize {
+struct USML_DLLEXPORT initialize {
     typedef T  argument_type ;
     typedef std::size_t    size_type ;
     static void zero( argument_type& a1, const argument_type s )
@@ -227,7 +228,7 @@ struct initialize {
  * for ublas::vector<T>
  */
 template<typename T>
-struct initialize< boost::numeric::ublas::vector<T> > {
+struct USML_DLLEXPORT initialize< boost::numeric::ublas::vector<T> > {
     typedef T  value_type ;
     typedef std::size_t    size_type ;
     typedef boost::numeric::ublas::vector<value_type>  argument_type ;
@@ -278,7 +279,7 @@ struct initialize< boost::numeric::ublas::vector<T> > {
  * for ublas::matrix<T>
  */
 template<typename T>
-struct initialize< boost::numeric::ublas::matrix<T> > {
+struct USML_DLLEXPORT initialize< boost::numeric::ublas::matrix<T> > {
     typedef T  value_type ;
     typedef std::size_t    size_type ;
     typedef boost::numeric::ublas::matrix<value_type>  argument_type ;

--- a/types/test/datagrid_test.cc
+++ b/types/test/datagrid_test.cc
@@ -140,6 +140,122 @@ BOOST_AUTO_TEST_CASE( linear_1d_test ) {
 }
 
 /**
+ * @ingroup types_test
+ * Interpolate 1-D linear field using a vector.
+ * Exercise all of the 1-D interpolation types.
+ * Generate errors if values differ by more that 1E-6 percent.
+ */
+BOOST_AUTO_TEST_CASE( linear_1d_vector_test ) {
+    typedef boost::numeric::ublas::vector<double>   element_type ;
+    element_type truth, nearest, linear, pchip;
+    size_t N = 3 ;
+
+    cout << "=== datagrid_test: linear_1d_vector_test ===" << endl;
+
+    // construct synthetic data for this test
+
+    seq_linear axis(1.0,2.0,9.0);
+    const seq_vector *ax[] = {&axis};
+    data_grid<element_type,1> grid( ax );
+    grid.edge_limit(0,false);
+
+    for ( size_t n=0; n < axis.size(); ++n ) {
+        element_type values(N, linear1d(axis(n)) ) ;
+        grid.data( &n, values );
+    }
+
+    // interpolate using all possible algorithms
+
+    cout << "x\ttruth\tnearest\tlinear\tpchip" << endl;
+    for ( double x=0.25; x <= 10.0; x += 0.25 ) {
+        double y = x ;
+        cout << y << "\t";
+        truth = scalar_vector<double>(N, linear1d(y)) ;
+        cout << truth << "\t";
+
+        grid.interp_type(0,GRID_INTERP_NEAREST);
+        nearest = grid.interpolate( &y );
+        cout << nearest << "\t";
+
+        grid.interp_type(0,GRID_INTERP_LINEAR);
+        linear = grid.interpolate( &y );
+        cout << linear << "\t";
+        for(size_t i=0; i<N; ++i) {
+            BOOST_CHECK_CLOSE( linear(i), truth(i), 1e-6 );
+        }
+
+        grid.interp_type(0,GRID_INTERP_PCHIP);
+        pchip = grid.interpolate( &y );
+        cout << pchip << "\t";
+        for(size_t i=0; i<N; ++i) {
+            BOOST_CHECK_CLOSE( pchip(i), truth(i), 1e-6 );
+        }
+
+        cout << endl;
+    }
+}
+
+/**
+ * @ingroup types_test
+ * Interpolate 1-D linear field using a matrix.
+ * Exercise all of the 1-D interpolation types.
+ * Generate errors if values differ by more that 1E-6 percent.
+ */
+BOOST_AUTO_TEST_CASE( linear_1d_matrix_test ) {
+    typedef boost::numeric::ublas::matrix<double>   element_type ;
+    element_type truth, nearest, linear, pchip;
+    size_t N = 2 ;
+
+    cout << "=== datagrid_test: linear_1d_vector_test ===" << endl;
+
+    // construct synthetic data for this test
+
+    seq_linear axis(1.0,2.0,9.0);
+    const seq_vector *ax[] = {&axis};
+    data_grid<element_type,1> grid( ax );
+    grid.edge_limit(0,false);
+
+    for ( size_t n=0; n < axis.size(); ++n ) {
+        element_type values(N, N, linear1d(axis(n)) ) ;
+        grid.data( &n, values );
+    }
+
+    // interpolate using all possible algorithms
+
+    cout << "x\ttruth\tnearest\tlinear\tpchip" << endl;
+    for ( double x=0.25; x <= 10.0; x += 0.25 ) {
+        double y = x ;
+        cout << y << "\t";
+        truth = scalar_matrix<double>(N, N, linear1d(y)) ;
+        cout << truth << "\t";
+
+        grid.interp_type(0,GRID_INTERP_NEAREST);
+        nearest = grid.interpolate( &y );
+        cout << nearest << "\t";
+
+        grid.interp_type(0,GRID_INTERP_LINEAR);
+        linear = grid.interpolate( &y );
+        cout << linear << "\t";
+        for(size_t i=0; i<N; ++i) {
+            for(size_t j=0; j<N; ++j) {
+                BOOST_CHECK_CLOSE( linear(i,j), truth(i,j), 1e-6 );
+            }
+        }
+
+        grid.interp_type(0,GRID_INTERP_PCHIP);
+        pchip = grid.interpolate( &y );
+        cout << pchip << "\t";
+        for(size_t i=0; i<N; ++i) {
+            for(size_t j=0; j<N; ++j) {
+                BOOST_CHECK_CLOSE( pchip(i,j), truth(i,j), 1e-6 );
+            }
+        }
+
+        cout << endl;
+    }
+}
+
+/**
  * Compute a cubic field value of 1-D interpolation test data
  */
 static double cubic1d( double axis ) {

--- a/types/test/datagrid_test.cc
+++ b/types/test/datagrid_test.cc
@@ -196,66 +196,6 @@ BOOST_AUTO_TEST_CASE( linear_1d_vector_test ) {
 }
 
 /**
- * @ingroup types_test
- * Interpolate 1-D linear field using a matrix.
- * Exercise all of the 1-D interpolation types.
- * Generate errors if values differ by more that 1E-6 percent.
- */
-BOOST_AUTO_TEST_CASE( linear_1d_matrix_test ) {
-    typedef boost::numeric::ublas::matrix<double>   element_type ;
-    element_type truth, nearest, linear, pchip;
-    size_t N = 2 ;
-
-    cout << "=== datagrid_test: linear_1d_vector_test ===" << endl;
-
-    // construct synthetic data for this test
-
-    seq_linear axis(1.0,2.0,9.0);
-    const seq_vector *ax[] = {&axis};
-    data_grid<element_type,1> grid( ax );
-    grid.edge_limit(0,false);
-
-    for ( size_t n=0; n < axis.size(); ++n ) {
-        element_type values(N, N, linear1d(axis(n)) ) ;
-        grid.data( &n, values );
-    }
-
-    // interpolate using all possible algorithms
-
-    cout << "x\ttruth\tnearest\tlinear\tpchip" << endl;
-    for ( double x=0.25; x <= 10.0; x += 0.25 ) {
-        double y = x ;
-        cout << y << "\t";
-        truth = scalar_matrix<double>(N, N, linear1d(y)) ;
-        cout << truth << "\t";
-
-        grid.interp_type(0,GRID_INTERP_NEAREST);
-        nearest = grid.interpolate( &y );
-        cout << nearest << "\t";
-
-        grid.interp_type(0,GRID_INTERP_LINEAR);
-        linear = grid.interpolate( &y );
-        cout << linear << "\t";
-        for(size_t i=0; i<N; ++i) {
-            for(size_t j=0; j<N; ++j) {
-                BOOST_CHECK_CLOSE( linear(i,j), truth(i,j), 1e-6 );
-            }
-        }
-
-        grid.interp_type(0,GRID_INTERP_PCHIP);
-        pchip = grid.interpolate( &y );
-        cout << pchip << "\t";
-        for(size_t i=0; i<N; ++i) {
-            for(size_t j=0; j<N; ++j) {
-                BOOST_CHECK_CLOSE( pchip(i,j), truth(i,j), 1e-6 );
-            }
-        }
-
-        cout << endl;
-    }
-}
-
-/**
  * Compute a cubic field value of 1-D interpolation test data
  */
 static double cubic1d( double axis ) {
@@ -305,6 +245,60 @@ BOOST_AUTO_TEST_CASE( cubic_1d_test ) {
         pchip = grid.interpolate( &x );
         cout << pchip << "\t";
         BOOST_CHECK_CLOSE( pchip, truth, 2.0 );
+
+        cout << endl;
+    }
+}
+
+/**
+ * @ingroup types_test
+ * Interpolate 1-D cubic field using a matrix.
+ * Exercise all of the 1-D interpolation types.
+ * Generate errors if values differ by more that 1E-6 percent.
+ */
+BOOST_AUTO_TEST_CASE( cubic_1d_matrix_test ) {
+    typedef boost::numeric::ublas::matrix<double>   element_type ;
+    element_type truth, nearest, linear, pchip;
+    size_t N = 2 ;
+
+    cout << "=== datagrid_test: cubic_1d_matrix_test ===" << endl;
+
+    // construct synthetic data for this test
+
+    seq_linear axis(1.0,2.0,9.0);
+    const seq_vector *ax[] = {&axis};
+    data_grid<element_type,1> grid( ax );
+    grid.edge_limit(0,false);
+
+    for ( size_t n=0; n < axis.size(); ++n ) {
+        element_type values(N, N, cubic1d(axis(n)) ) ;
+        grid.data( &n, values );
+    }
+
+    // interpolate using all possible algorithms
+
+    cout << "x\ttruth\tnearest\tlinear\tpchip" << endl;
+    for ( double x=1.0; x <= 9.0; x += 0.25 ) {
+        cout << x << "\t";
+        truth = element_type(N, N, cubic1d(x)) ;
+        cout << truth << "\t";
+
+        grid.interp_type(0,GRID_INTERP_NEAREST);
+        nearest = grid.interpolate( &x );
+        cout << nearest << "\t";
+
+        grid.interp_type(0,GRID_INTERP_LINEAR);
+        linear = grid.interpolate( &x );
+        cout << linear << "\t";
+
+        grid.interp_type(0,GRID_INTERP_PCHIP);
+        pchip = grid.interpolate( &x );
+        cout << pchip << "\t";
+        for(size_t i=0; i<N; ++i) {
+            for(size_t j=0; j<N; ++j) {
+                BOOST_CHECK_CLOSE( pchip(i,j), truth(i,j), 2.0 );
+            }
+        }
 
         cout << endl;
     }


### PR DESCRIPTION
Added new functionality to data_grid, hence extending its capabilities to now allow storage of generic data within the grid. At present, functionality is provided for all integral types and ublas::vector/matrix element types, however, if the user desired to use other types, it would be possible to do so by defining the following specialized structures inside of data_grid_functors.h, or another file that must be include inside of data_grid.h, and the following binary operators:

* derivate::compute(...) this function computes the middle point derivate of the data requested
* end_point_derivate::compute(...) this function computes the end point derivates, when an  interpolation falls at the edge of a dimension
* initialize::zero(...) this function prevents valgrind from complaining about uninitialized values and unconditional jump warnings
* initialize::value(...) this function is an alias of the operator=
* binary operators(both left and right operands): +, -, /, *(multiply), and operator=

Providing the following, will allow the user to extend data_grid to store any type of data that can be conceived.