### PR TITLE
Fix frequencies_overlap call.

### DIFF
--- a/eigenverb/wavefront_generator.cc
+++ b/eigenverb/wavefront_generator.cc
@@ -4,7 +4,7 @@
  */
 
 //#define PRINTOUT_WAVE_DATA
-#define NO_EIGENVERBS
+//#define NO_EIGENVERBS
 
 #include <boost/foreach.hpp>
 #include <usml/eigenverb/wavefront_generator.h>

--- a/sensors/sensor_pair_manager.cc
+++ b/sensors/sensor_pair_manager.cc
@@ -487,7 +487,8 @@ void sensor_pair_manager::add_multistatic_source(sensor_model* source) {
             if ( receiver_sensor != NULL &&
                     receiver_sensor->receiver()->multistatic() &&
                     frequencies_overlap(source->source()->frequencies(), 
-                                        receiver_sensor->receiver()->frequencies()) )
+                    receiver_sensor->receiver()->min_active_freq(),
+                    receiver_sensor->receiver()->max_active_freq()) )
 			{
                 std::string hash_key = generate_hash_key(sourceID, receiverID);
                 sensor_pair* pair = new sensor_pair(source, receiver_sensor);
@@ -514,7 +515,8 @@ void sensor_pair_manager::add_multistatic_receiver(sensor_model* receiver) {
             if ( source_sensor != NULL && 
                     source_sensor->source()->multistatic() &&
                     frequencies_overlap(source_sensor->source()->frequencies(), 
-                                        receiver->receiver()->frequencies() ) )
+                                        receiver->receiver()->min_active_freq(),
+                                        receiver->receiver()->max_active_freq()) )
 			{
                 std::string hash_key = generate_hash_key(sourceID, receiverID);
                 sensor_pair* pair = new sensor_pair(source_sensor, receiver);
@@ -559,7 +561,8 @@ void sensor_pair_manager::remove_multistatic_source(sensor_model* source) {
             if ( receiver_sensor != NULL &&
                     receiver_sensor->receiver()->multistatic() &&
                     frequencies_overlap(source->source()->frequencies(), 
-                                        receiver_sensor->receiver()->frequencies()) )
+                                        receiver_sensor->receiver()->min_active_freq(),
+                                        receiver_sensor->receiver()->max_active_freq()) )
 			{
                 std::string hash_key = generate_hash_key(sourceID, receiverID);
 				sensor_pair* pair = _map.find(hash_key);
@@ -589,7 +592,8 @@ void sensor_pair_manager::remove_multistatic_receiver(sensor_model* receiver) {
             if ( source_sensor != NULL && 
                 source_sensor->source()->multistatic() && 
                 frequencies_overlap(source_sensor->source()->frequencies(), 
-                                    receiver->receiver()->frequencies()) )
+                                    receiver->receiver()->min_active_freq(),
+                                    receiver->receiver()->max_active_freq()) )
 			{
                 std::string hash_key = generate_hash_key(sourceID, receiverID);
 				sensor_pair* pair = _map.find(hash_key);
@@ -612,15 +616,15 @@ void sensor_pair_manager::remove_multistatic_receiver(sensor_model* receiver) {
 * Utility to determine if two frequency ranges overlap
 * Used to determine of a sensor_pair needs to be created.
 */
-bool sensor_pair_manager::frequencies_overlap(const seq_vector* src_freq, const seq_vector* rcv_freq) {
-
+bool sensor_pair_manager::frequencies_overlap(const seq_vector* src_freq, 
+                                                double  rcv_min, double rcv_max) {
     // Get source min and max
     double src_min = *( src_freq->data().begin() );
     double src_max = *( src_freq->data().end() - 1 );
 
-    // Get receiver min and max
-    double rcv_min = *( rcv_freq->data().begin() );
-    double rcv_max = *( rcv_freq->data().end() - 1 );
+    //// Get receiver min and max
+    //double rcv_min = *( rcv_freq->data().begin() );
+    //double rcv_max = *( rcv_freq->data().end() - 1 );
 
     bool overlap = src_min <= rcv_max &&  rcv_min <= src_max;
     

--- a/sensors/sensor_pair_manager.h
+++ b/sensors/sensor_pair_manager.h
@@ -315,10 +315,11 @@ private:
      * Utility to determine if two frequency ranges overlap
      * Used to determine if a sensor_pair needs to be created.
      * @param    src_freq  frequency range for source.
-     * @param    rcv_freq  frequency range for receiver.
-     * @return  true when frequency ranges overlap.
+     * @param    rcv_min   minimum active frequency for the receiver.
+     * @param    rcv_max   maximum active frequency for the receiver.
+     * @return   true when frequency ranges overlap.
      */
-    bool frequencies_overlap(const seq_vector* src_freq, const seq_vector* rcv_freq);
+    bool frequencies_overlap(const seq_vector* src_freq, double rcv_min, double rcv_max);
 
     /**
      * Hide access to default constructor.


### PR DESCRIPTION
Fix frequencies_overlap call to use receiver min_active and max_active vs receive_frequecies, begin and end-1.