### PR TITLE
Add explicit casts to certain inlined complex functions

### DIFF
--- a/ublas/math_traits.h
+++ b/ublas/math_traits.h
@@ -715,11 +715,11 @@ template<> struct math_traits<complex<float> >
     }
     static inline value_type pow(const_reference t, int e)
     {
-        return std::pow(t, e);
+        return std::complex<float>(std::pow(t, e));
     }
     static inline value_type pow(const_reference t, const_reference e)
     {
-        return std::pow(t, e);
+        return std::complex<float>(std::pow(t, e));
     }
 
     //*********************************************************
@@ -727,11 +727,11 @@ template<> struct math_traits<complex<float> >
 
     static inline value_type pow(const_reference t, real_type e)
     {
-        return std::pow(t, e);
+        return std::complex<float>(std::pow(t, e));
     }
     static inline value_type pow(real_type t, const_reference e)
     {
-        return std::pow(t, e);
+        return std::complex<float>(std::pow(t, e));
     }
 
 };


### PR DESCRIPTION
This was (somehow) the only code change needed to get this to compile out of the box on OSX Catalina. Mostly submitting this pull as a documentation of the exact workaround necessary, but if it's useful, let me know and I can clean it up for proper submission.

After this change, steps to build on (relatively stock) OSX Catalina are:
```
brew tap homebrew/science
brew install netcdf boost cmake
git clone git@github.com:campreilly/UnderSeaModelingLibrary.git usml
cd usml
cmake .
make
./usml_test
```

This produced two test failures. Not sure if these are reflected on a more standard build environment or are a product of my env + my changes.
