### PR TITLE
Fixed missing copying some parameters on eigenverb_interpolator (issue

### DIFF
--- a/eigenverb/eigenverb_interpolator.cc
+++ b/eigenverb/eigenverb_interpolator.cc
@@ -40,6 +40,12 @@ void eigenverb_interpolator::interpolate(
 
 	// copy terms that are not frequency dependent
 
+	new_verb->length = verb.length;
+	new_verb->width = verb.width;
+	new_verb->source_de = verb.source_de;
+	new_verb->source_az = verb.source_az;
+	new_verb->caustic = verb.caustic;
+	
 	new_verb->length2 = verb.length2 ;
 	new_verb->width2 = verb.width2 ;
 	new_verb->time = verb.time ;


### PR DESCRIPTION
eigenverb_interpolator::interpolate is not copying some parameters from origin eigenverb to the interpolated eigenverb. That prevents envelope_generator to locate them on the rtree and add their contribution to the envolope. This behavior can be seen when running 'reverb_analytic_test' and openning/plotting the 'intensity' variable over traverl_time from 'envelopes_src_1_rcv1.nc' file. Flat reverberation is found, like in the following image:

![image](https://user-images.githubusercontent.com/27335061/96991138-4b3b8880-1528-11eb-8de6-bb03b43672c1.png)

Fixes #248 